### PR TITLE
fix broken example in documentation

### DIFF
--- a/bids/grabbids/README.md
+++ b/bids/grabbids/README.md
@@ -90,7 +90,7 @@ Once we've initialized a `Layout`, we can do simple things like getting a list o
 Counting is kind of trivial; everyone can count! More usefully, we can run simple logical queries, returning the results in a variety of formats:
 
 ```python
->>> files = layout.get(subject='sub-0[12]', run=1, extensions='.nii.gz')
+>>> files = layout.get(subject='0[12]', run=1, extensions='.nii.gz')
 >>> files[0]
 File(filename='7t_trt/sub-02/ses-1/fmap/sub-02_ses-1_run-1_magnitude1.nii.gz', subject='sub-02', run='run-1', session='ses-1', type='magnitude1')
 


### PR DESCRIPTION
The 'sub-' prefix is already inserted by the config, so including it in the query breaks it. Took me a while to work this out. Hopefully saves someone else a few minutes of confusion.

By the way, there is a very similar version of this repo at https://github.com/INCF/grabbit. Let me know if I should be working with that one instead.