### PR TITLE
Add kwargs to BIDSLayout init

### DIFF
--- a/bids/grabbids/bids_layout.py
+++ b/bids/grabbids/bids_layout.py
@@ -14,11 +14,11 @@ __all__ = ['BIDSLayout']
 
 
 class BIDSLayout(Layout):
-    def __init__(self, path, config=None):
+    def __init__(self, path, config=None, **kwargs):
         if config is None:
             root = dirname(realpath(__file__))
             config = pathjoin(root, 'config', 'bids.json')
-        super(BIDSLayout, self).__init__(path, config, dynamic_getters=True)
+        super(BIDSLayout, self).__init__(path, config, dynamic_getters=True, **kwargs)
 
     def get_metadata(self, path):
         sidecarJSON = path.replace(".nii.gz", ".json").replace(".nii", ".json")


### PR DESCRIPTION
A new option was added to grabbit classes. In order to expose these to packages using pybids having the init of BIDSLayout take kwargs and then pass them on in the super call to the grabbit Layout class is necessary.