### PR TITLE
ENH: Use abspath instead of realpath

### DIFF
--- a/bids/grabbids/bids_layout.py
+++ b/bids/grabbids/bids_layout.py
@@ -3,7 +3,7 @@ import re
 import json
 
 from os.path import dirname
-from os.path import realpath
+from os.path import abspath
 from os.path import join as pathjoin
 from os.path import basename
 
@@ -15,7 +15,7 @@ __all__ = ['BIDSLayout']
 class BIDSLayout(Layout):
     def __init__(self, path, config=None, **kwargs):
         if config is None:
-            root = dirname(realpath(__file__))
+            root = dirname(abspath(__file__))
             config = pathjoin(root, 'config', 'bids.json')
         super(BIDSLayout, self).__init__(path, config,
                                          dynamic_getters=True, **kwargs)
@@ -26,7 +26,7 @@ class BIDSLayout(Layout):
         return True
 
     def get_metadata(self, path, **kwargs):
-        path = realpath(path)
+        path = abspath(path)
 
         if path not in self.files:
             raise ValueError("File '%s' could not be found in the current BIDS"


### PR DESCRIPTION
`os.path.realpath` dereferences symlinks, which will almost always destroy the naming structure required by BIDS. `git-annex`-managed datasets, such as those obtained through datalad, cannot be used in indirect mode and still work with pybids.

`os.path.abspath` puts paths into a normal form, without potentially rewriting paths outside the BIDS directory.

Are there any reasons to use `realpath` that I'm missing?