### PR TITLE
OS-compatible path sep; fixes breaking windows tests

### DIFF
--- a/bids/grabbids/config/bids.json
+++ b/bids/grabbids/config/bids.json
@@ -8,7 +8,7 @@
         {
             "name": "session",
             "pattern": "ses-([a-zA-Z0-9]+)",
-            "mandatory": false, 
+            "mandatory": false,
             "directory": "{{root}}/{subject}/{session}",
             "missing_value": "ses-1"
         },
@@ -46,7 +46,7 @@
         },
         {
             "name": "modality",
-            "pattern": "\/(func|anat|fmap|dwi)\/"
+            "pattern": "[/\\\\](func|anat|fmap|dwi)[/\\\\]"
         },
         {
             "name": "dir",


### PR DESCRIPTION
Fixes breaking tests on Windows. The problem was that the forward slash was hardcoded as the path separator in the JSON config file.