### PR TITLE
forces utf-8 encoding; fixes #70

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,16 +8,8 @@ matrix:
   include:
     - os: osx
       env:
-         - PYTHON_VERSION=2.7
-         - MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda2-latest-MacOSX-x86_64.sh"
-    - os: osx
-      env:
          - PYTHON_VERSION=3.5
          - MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh"
-    - os: linux
-      env:
-         - PYTHON_VERSION=2.7
-         - MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh"
     - os: linux
       env:
          - PYTHON_VERSION=3.5

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,11 +2,6 @@ build: false
 
 environment:
   matrix:
-    - PYTHON: "C:\\Python27"
-      PYTHON_VERSION: "2.7.8"
-      PYTHON_ARCH: "32"
-      MINICONDA: C:\Miniconda
-
     - PYTHON: "C:\\Python35"
       PYTHON_VERSION: "3.5.1"
       PYTHON_ARCH: "32"

--- a/bids/grabbids/bids_layout.py
+++ b/bids/grabbids/bids_layout.py
@@ -5,7 +5,6 @@ import json
 from os.path import dirname
 from os.path import abspath
 from os.path import join as pathjoin
-from os.path import basename
 
 from grabbit import Layout
 
@@ -48,12 +47,15 @@ class BIDSLayout(Layout):
     def get_metadata(self, path, **kwargs):
 
         potentialJSONs = self._get_nearest_helper(path, '.json', **kwargs)
-        if not isinstance(potentialJSONs, list): return potentialJSONs
+
+        if not isinstance(potentialJSONs, list):
+            return potentialJSONs
 
         merged_param_dict = {}
         for json_file_path in reversed(potentialJSONs):
             if os.path.exists(json_file_path):
-                param_dict = json.load(open(json_file_path, "r"))
+                param_dict = json.load(open(json_file_path, "r",
+                                            encoding='utf-8'))
                 merged_param_dict.update(param_dict)
 
         return merged_param_dict


### PR DESCRIPTION
Forces utf-8 encoding when reading JSON file contents. This will address problems on platforms where utf-8 is not the default encoding. This shouldn't cause anyone problems unless they're already in violation of the BIDS spec, as JSON files are supposed to always be UTF-8 encoded.