### PR TITLE
Somewhat misleading error message by BIDSLayout.get_metadata()

### DIFF
--- a/bids/grabbids/bids_layout.py
+++ b/bids/grabbids/bids_layout.py
@@ -44,8 +44,9 @@ class BIDSLayout(Layout):
         path = abspath(path)
 
         if path not in self.files:
-            raise ValueError("File '%s' could not be found in the current BIDS"
-                             " project." % path)
+            raise ValueError(
+                "File '%s' does not match any specification in the current "
+                "BIDS project." % path)
 
         if not type:
             # Constrain the search to .json files with the same type as target


### PR DESCRIPTION
When I query a file that grabbit has nothing to say about, I get an error that can be mistaken for "there is no such file". Maybe one could phrase it like:

    "File '%s' does not match any specification in the current BIDS project."

```
l=BIDSLayout('.')
l.get_metadata('participants.tsv')
--------------------------------------------------------------------------
ValueError                               Traceback (most recent call last)
<ipython-input-35-81dce41d2921> in <module>()
----> 1 l.get_metadata('participants.tsv')

/home/mih/.local/lib/python2.7/site-packages/bids/grabbids/bids_layout.pyc in get_metadata(self, path, **kwargs)
     43     def get_metadata(self, path, **kwargs):
     44 
---> 45         potentialJSONs = self.get_nearest_helper(path, '.json', **kwargs)
     46 
     47         merged_param_dict = {}

/home/mih/.local/lib/python2.7/site-packages/bids/grabbids/bids_layout.pyc in get_nearest_helper(self, path, extension, type, **kwargs)
     31         if path not in self.files:
     32             raise ValueError("File '%s' could not be found in the current BIDS"
---> 33                              " project." % path)
     34 
     35         if not type:

ValueError: File '/home/mih/forrest/collection/phase2/participants.tsv' could not be found in the current BIDS project.
from os.path import exists
exists('participants.tsv')
True
```