### PR TITLE
Restore PY2 compat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,16 @@ matrix:
   include:
     - os: osx
       env:
+         - PYTHON_VERSION=2.7
+         - MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda2-latest-MacOSX-x86_64.sh"
+    - os: osx
+      env:
          - PYTHON_VERSION=3.5
          - MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh"
+    - os: linux
+      env:
+         - PYTHON_VERSION=2.7
+         - MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh"
     - os: linux
       env:
          - PYTHON_VERSION=3.5

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,11 @@ build: false
 
 environment:
   matrix:
+    - PYTHON: "C:\\Python27"
+      PYTHON_VERSION: "2.7.8"
+      PYTHON_ARCH: "32"
+      MINICONDA: C:\Miniconda
+
     - PYTHON: "C:\\Python35"
       PYTHON_VERSION: "3.5.1"
       PYTHON_ARCH: "32"

--- a/bids/grabbids/bids_layout.py
+++ b/bids/grabbids/bids_layout.py
@@ -1,6 +1,8 @@
 import os
 import json
 
+from io import open
+
 from os.path import dirname
 from os.path import abspath
 from os.path import join as pathjoin


### PR DESCRIPTION
```
/home/mih/.local/lib/python2.7/site-packages/bids/grabbids/bids_layout.pyc in get_metadata(self, path, **kwargs)
     83             if os.path.exists(json_file_path):
     84                 param_dict = json.load(open(json_file_path, "r",
---> 85                                             encoding='utf-8'))
     86                 merged_param_dict.update(param_dict)
     87 

TypeError: 'encoding' is an invalid keyword argument for this function
```

I am aware that there is no upstream interest in PY2. Please advice on possible ways to be able to keep building on pybids for applications that need PY2 compatibility.