### PR TITLE
Legit side car files for 'recording's are ignored

### DIFF
--- a/bids/grabbids/config/bids.json
+++ b/bids/grabbids/config/bids.json
@@ -60,6 +60,10 @@
             "pattern": "dir-([a-zA-Z0-9]+)"
         },
         {
+            "name": "recording",
+            "pattern": "recording-([a-zA-Z0-9]+)"
+        },
+        {
             "name": "acq",
             "pattern": "acq-([a-zA-Z0-9]+)"
         }


### PR DESCRIPTION
Here is the demo

```
In [1]: from bids.grabbids import BIDSLayout
In [2]: l=BIDSLayout('.')
In [3]: l.get_metadata('sub-03/ses-localizer/func/sub-03_ses-localizer_task-retmapccw_run-
   ...: 1_recording-cardresp_physio.tsv.gz')
Out[3]: 
{u'CogAtlasID': u'http://www.cognitiveatlas.org/term/id/trm_558c4d3105abf',
 u'TaskDescription': u'Participants fixate the center of the screen while a counter-clockwise rotating wedge (not a properlor) stimulus is being displayed.',
 u'TaskName': u'retmapccw'}
In [4]: cat recording-cardresp_physio.json
{
    "SamplingFrequency": 500.0, 
    "StartTime": 0.0, 
    "Columns": [
        "trigger", 
        "cardiac", 
        "respiratory"
    ], 
    "ContentDescription": "Activity recorded with a pulse oximeter (cardiac) and respiration belt."
}
```

I think the name and location of the file is legit (I believe I even discussed it with BIDS people when assembling the dataset (ds113d on openfmri)).