### PR TITLE
ENH: Derivative entities

### DIFF
--- a/bids/grabbids/bids_layout.py
+++ b/bids/grabbids/bids_layout.py
@@ -31,7 +31,7 @@ class BIDSLayout(Layout):
         for ext in extensions or []:
             with open(pathjoin(root, 'config', '%s.json' % ext)) as fobj:
                 ext_config = json.load(fobj)
-                config['entities'].update(ext_config['entities'])
+                config['entities'].extend(ext_config['entities'])
 
         super(BIDSLayout, self).__init__(path, config,
                                          dynamic_getters=True, **kwargs)

--- a/bids/grabbids/bids_layout.py
+++ b/bids/grabbids/bids_layout.py
@@ -1,5 +1,6 @@
 import os
 import json
+import collections
 
 from io import open
 
@@ -16,12 +17,22 @@ __all__ = ['BIDSLayout']
 class BIDSLayout(Layout):
 
     def __init__(self, path, config=None, validate=False,
-                 index_associated=True, **kwargs):
+                 index_associated=True, extensions=None, **kwargs):
         self.validator = BIDSValidator(index_associated=index_associated)
         self.validate = validate
         if config is None:
             root = dirname(abspath(__file__))
             config = pathjoin(root, 'config', 'bids.json')
+
+        # Use dictionary config to allow extension augmentations
+        if not isinstance(config, collections.Mapping):
+            with open(config) as fobj:
+                config = json.load(fobj)
+        for ext in extensions or []:
+            with open(pathjoin(root, 'config', '%s.json' % ext)) as fobj:
+                ext_config = json.load(fobj)
+                config['entities'].update(ext_config['entities'])
+
         super(BIDSLayout, self).__init__(path, config,
                                          dynamic_getters=True, **kwargs)
 

--- a/bids/grabbids/config/bids.json
+++ b/bids/grabbids/config/bids.json
@@ -62,6 +62,18 @@
         {
             "name": "acq",
             "pattern": "acq-([a-zA-Z0-9]+)"
+        },
+        {
+            "name": "target",
+            "pattern": "target-([a-zA-Z0-9]+)"
+        },
+        {
+            "name": "space",
+            "pattern": "space-([a-zA-Z0-9]+)"
+        },
+        {
+            "name": "class",
+            "pattern": "class-([a-zA-Z0-9]+)"
         }
     ]
 }

--- a/bids/grabbids/config/bids.json
+++ b/bids/grabbids/config/bids.json
@@ -74,6 +74,10 @@
         {
             "name": "class",
             "pattern": "class-([a-zA-Z0-9]+)"
+        },
+        {
+            "name": "variant",
+            "pattern": "variant-([a-zA-Z0-9]+)"
         }
     ]
 }

--- a/bids/grabbids/config/bids.json
+++ b/bids/grabbids/config/bids.json
@@ -62,22 +62,6 @@
         {
             "name": "acq",
             "pattern": "acq-([a-zA-Z0-9]+)"
-        },
-        {
-            "name": "target",
-            "pattern": "target-([a-zA-Z0-9]+)"
-        },
-        {
-            "name": "space",
-            "pattern": "space-([a-zA-Z0-9]+)"
-        },
-        {
-            "name": "class",
-            "pattern": "class-([a-zA-Z0-9]+)"
-        },
-        {
-            "name": "variant",
-            "pattern": "variant-([a-zA-Z0-9]+)"
         }
     ]
 }

--- a/bids/grabbids/config/derivatives.json
+++ b/bids/grabbids/config/derivatives.json
@@ -1,0 +1,20 @@
+{
+    "entities": [
+        {
+            "name": "target",
+            "pattern": "target-([a-zA-Z0-9]+)"
+        },
+        {
+            "name": "space",
+            "pattern": "space-([a-zA-Z0-9]+)"
+        },
+        {
+            "name": "class",
+            "pattern": "class-([a-zA-Z0-9]+)"
+        },
+        {
+            "name": "variant",
+            "pattern": "variant-([a-zA-Z0-9]+)"
+        }
+    ]
+}

--- a/bids/grabbids/config/derivatives.json
+++ b/bids/grabbids/config/derivatives.json
@@ -9,8 +9,24 @@
             "pattern": "space-([a-zA-Z0-9]+)"
         },
         {
+            "name": "res",
+            "pattern": "res-([a-zA-Z0-9]+)"
+        },
+        {
             "name": "class",
             "pattern": "class-([a-zA-Z0-9]+)"
+        },
+        {
+            "name": "atlas",
+            "pattern": "atlas-([a-zA-Z0-9]+)"
+        },
+        {
+            "name": "roi",
+            "pattern": "roi-([a-zA-Z0-9]+)"
+        },
+        {
+            "name": "label",
+            "pattern": "label-([a-zA-Z0-9]+)"
         },
         {
             "name": "variant",

--- a/bids/grabbids/tests/test_grabbids.py
+++ b/bids/grabbids/tests/test_grabbids.py
@@ -114,3 +114,7 @@ def test_exclude(testlayout2):
         testlayout2.root, 'models/ds-005_type-russ_sub-all_model.json') \
         not in testlayout2.files
     assert 'all' not in testlayout2.get_subjects()
+
+
+def test_layout_with_derivs(testlayout3):
+    assert isinstance(testlayout3.files, dict)

--- a/bids/grabbids/tests/test_grabbids.py
+++ b/bids/grabbids/tests/test_grabbids.py
@@ -19,6 +19,12 @@ def testlayout2():
     return BIDSLayout(data_dir)
 
 
+@pytest.fixture
+def testlayout3():
+    data_dir = join(dirname(__file__), 'data', 'ds005')
+    return BIDSLayout(data_dir, extensions=['derivatives'])
+
+
 def test_layout_init(testlayout1):
     assert isinstance(testlayout1.files, dict)
 


### PR DESCRIPTION
In order to effectively select outputs of fmriprep (and, presumably, other derivatives-producing programs), the following entries in `bids.json` are required: `target`, `space`, `class`, `variant`.