### PR TITLE
more informative failure in get_nearest_helper; fixes #82

### DIFF
--- a/bids/grabbids/bids_layout.py
+++ b/bids/grabbids/bids_layout.py
@@ -62,7 +62,11 @@ class BIDSLayout(Layout):
                 "BIDS project." % path)
 
         if not type:
-            # Constrain the search to .json files with the same type as target
+            if 'type' not in self.files[path].entities:
+                raise ValueError(
+                    "File '%s' does not have a valid type definition, most "
+                    "likely because it is not a valid BIDS file." % path
+                )
             type = self.files[path].entities['type']
 
         tmp = self.get_nearest(path, extensions=extension, all_=True,


### PR DESCRIPTION
To work with `_get_nearest_helper`, files have to have a defined `type`. Currently invalid files produce an uninformative `KeyError`; this returns a more informative message.