### PR TITLE
FIX: install all json files under config during setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ opts = dict(name=NAME,
             platforms=PLATFORMS,
             version=VERSION,
             packages=PACKAGES,
-            package_data={'bids': ['grabbids/config/bids.json']},
+            package_data={'bids': ['grabbids/config/*.json']},
             install_requires=REQUIRES)
 
 


### PR DESCRIPTION
Otherwise `derivatives.json` doesn't get installed