### PR TITLE
Column sampling rate

### DIFF
--- a/bids/analysis/tests/test_base.py
+++ b/bids/analysis/tests/test_base.py
@@ -32,7 +32,7 @@ def test_analysis_smoke_test(analysis):
     assert len(result) == 16
     assert len(result[0]) == 2
     assert result[0].data.shape == (24, 2)
-    assert result[0].entities == {'subject': 1}
+    assert result[0].entities == {'subject': '01'}
 
     # Participant level and also check integer-based indexing
     result = analysis['participant'].get_Xy()
@@ -44,8 +44,7 @@ def test_analysis_smoke_test(analysis):
     assert len(result) == 1
     data = result[0].data
     assert len(data) == 160
-    # Not 16 because subs get represented as both ints and str--should fix!
-    assert data['subject'].nunique() == 32
+    assert data['subject'].nunique() == 16
     # Make sure columns from different levels exist
     varset = {'sex', 'age', 'RT', 'respnum'}
     assert not (varset - set(data['condition'].unique()))

--- a/bids/analysis/tests/test_transformations.py
+++ b/bids/analysis/tests/test_transformations.py
@@ -49,6 +49,7 @@ def test_scale(collection):
 
 def test_orthogonalize_dense(collection):
     transform.factor(collection, 'trial_type', sep='/')
+    print(collection.columns.keys())
     pg_pre = collection['trial_type/parametric gain'].to_dense().values
     rt = collection['RT'].to_dense().values
     transform.orthogonalize(collection, cols='trial_type/parametric gain',
@@ -87,28 +88,28 @@ def test_split(collection):
 
     # Grouping SparseEventColumn by one column
     transform.split(collection, ['RT'], ['respcat'])
-    assert 'RT/0' in collection.columns.keys() and \
-           'RT/-1' in collection.columns.keys()
-    rt_post_onsets = np.r_[collection['RT/0'].onset,
-                           collection['RT/-1'].onset,
-                           collection['RT/1'].onset]
+    assert 'RT.0' in collection.columns.keys() and \
+           'RT.-1' in collection.columns.keys()
+    rt_post_onsets = np.r_[collection['RT.0'].onset,
+                           collection['RT.-1'].onset,
+                           collection['RT.1'].onset]
     assert np.array_equal(rt_pre_onsets.sort(), rt_post_onsets.sort())
 
     # Grouping SparseEventColumn by multiple columns
     transform.split(collection, cols=['RT_2'], by=['respcat', 'loss'])
-    assert 'RT_2/-1_13' in collection.columns.keys() and \
-           'RT_2/1_13' in collection.columns.keys()
+    assert 'RT_2.-1_13' in collection.columns.keys() and \
+           'RT_2.1_13' in collection.columns.keys()
 
     # Grouping by DenseEventColumn
     transform.split(collection, cols='RT_3', by='respcat')
-    assert 'RT_3/respcat[0]' in collection.columns.keys()
-    assert len(collection['RT_3/respcat[0]'].values) == \
+    assert 'RT_3.respcat[0]' in collection.columns.keys()
+    assert len(collection['RT_3.respcat[0]'].values) == \
         len(collection['RT_3'].values)
 
     # Grouping by entities in the index
     collection['RT_4'] = orig.clone(name='RT_4')
     transform.split(collection, cols=['RT_4'], by=['respcat', 'run'])
-    assert 'RT_4/-1_3' in collection.columns.keys()
+    assert 'RT_4.-1_3' in collection.columns.keys()
 
 
 def test_resample_dense(collection):

--- a/bids/analysis/tests/test_transformations.py
+++ b/bids/analysis/tests/test_transformations.py
@@ -49,7 +49,6 @@ def test_scale(collection):
 
 def test_orthogonalize_dense(collection):
     transform.factor(collection, 'trial_type', sep='/')
-    print(collection.columns.keys())
     pg_pre = collection['trial_type/parametric gain'].to_dense().values
     rt = collection['RT'].to_dense().values
     transform.orthogonalize(collection, cols='trial_type/parametric gain',

--- a/bids/analysis/tests/test_variables.py
+++ b/bids/analysis/tests/test_variables.py
@@ -32,6 +32,18 @@ def collection():
 #     load_event_variables(layout)
 
 
+def test_resample_dense_event_column(collection):
+    col = collection['RT'].to_dense()
+    col2 = col.clone()
+    sr = col.sampling_rate * 5
+    col2.resample(sr)
+    assert len(col.values) * 5 == len(col2.values)
+    assert col2.sampling_rate == 50
+    assert col.sampling_rate == 10
+    assert collection.sampling_rate == 10
+    assert len(col2.index) == len(collection.index) * 50 / 10
+
+
 def test_aggregate_column(collection):
     col = collection['RT']
     agg_col = col.aggregate('subject')

--- a/bids/analysis/tests/test_variables.py
+++ b/bids/analysis/tests/test_variables.py
@@ -136,7 +136,7 @@ def test_get_design_matrix(collection):
     dm = collection.get_design_matrix(columns=['RT', 'parametric gain'],
                                       groupby=['subject', 'run'],
                                       subject=subs)
-    assert set(dm['subject'].unique()) == set(sub_ids)
+    assert set(dm['subject'].unique()) == set(subs)
     cols = set(['amplitude', 'onset', 'duration', 'subject', 'run', 'task',
                 'condition', 'modality', 'type'])
     assert set(dm.columns) == cols

--- a/bids/analysis/transform/base.py
+++ b/bids/analysis/transform/base.py
@@ -290,7 +290,6 @@ class Transformation(object):
                 col.name = _output
                 self.collection[_output] = col
 
-
     @abstractmethod
     def _transform(self, **kwargs):
         pass
@@ -339,7 +338,7 @@ class Transformation(object):
                 # Compare 1st col with each of the others
                 fc = get_col_data(cols[0])
                 if not all([compare_cols(fc, get_col_data(c))
-                           for c in cols[1:]]):
+                            for c in cols[1:]]):
                     msg = "Misaligned sparse columns found."
                     if force:
                         msg += (" Forcing all sparse columns to dense in order"

--- a/bids/analysis/transform/munge.py
+++ b/bids/analysis/transform/munge.py
@@ -166,7 +166,7 @@ class factor(Transformation):
     _return_type = 'column'
     _allow_categorical = ('cols',)
 
-    def _transform(self, col, constraint='none', ref_level=None, sep='_'):
+    def _transform(self, col, constraint='none', ref_level=None, sep='.'):
 
         result = []
         data = col.to_df()

--- a/bids/analysis/variables.py
+++ b/bids/analysis/variables.py
@@ -634,7 +634,7 @@ class SimpleColumn(BIDSColumn):
 
         subsets = []
         for i, (name, g) in enumerate(data.groupby(grouper)):
-            name = '%s.%s' % (name, self.name)
+            name = '%s.%s' % (self.name, name)
             col = self.__class__(self.collection, name, g, level_name=name,
                                  factor_name=self.name, level_index=i)
             subsets.append(col)
@@ -707,7 +707,7 @@ class DenseEventColumn(BIDSColumn):
         '''
         df = grouper * self.values
         names = df.columns
-        return [DenseEventColumn(self.collection, '%s/%s' % (self.name, name),
+        return [DenseEventColumn(self.collection, '%s.%s' % (self.name, name),
                                  df[name].values)
                 for i, name in enumerate(names)]
 


### PR DESCRIPTION
This PR allows individual `DenseEventColumn`s to have different sampling rates. This means we no longer have to resample all temporal variables to a common sampling rate when they're first read in. Instead, resampling can be deferred until it can't be avoided (and, in the case of variables that natively have the same sampling rate as the eventual output sampling rate, no resampling needs to be performed at all).