### PR TITLE
ENH: Include all entities in bids.json

### DIFF
--- a/bids/grabbids/config/bids.json
+++ b/bids/grabbids/config/bids.json
@@ -6,42 +6,63 @@
         {
             "name": "subject",
             "pattern": ".*sub-([a-zA-Z0-9]+)",
-            "directory": "{{root}}/{subject}"
+            "directory": "{{root}}/{subject}",
+            "aliases": ["sub"]
         },
         {
             "name": "session",
             "pattern": "ses-([a-zA-Z0-9]+)",
             "mandatory": false,
             "directory": "{{root}}/{subject}/{session}",
-            "missing_value": "ses-1"
-        },
-        {
-            "name": "run",
-            "pattern": "run-(\\d+)"
-        },
-        {
-            "name": "type",
-            "pattern": "[._]*([a-zA-Z0-9]*?)\\.[^/\\\\]+$"
+            "missing_value": "ses-1",
+            "aliases": ["ses"]
         },
         {
             "name": "task",
             "pattern": "task-([a-zA-Z0-9]+)"
         },
         {
-            "name": "scans",
-            "pattern": "(.*\\_scans.tsv)$"
+            "name": "acquisition",
+            "pattern": "acq-([a-zA-Z0-9]+)",
+            "aliases": ["acq"]
+        },
+        {
+            "name": "ce",
+            "pattern": "ce-([a-zA-Z0-9]+)"
+        },
+        {
+            "name": "reconstruction",
+            "pattern": "rec-([a-zA-Z0-9]+)",
+            "aliases": ["rec"]
+        },
+        {
+            "name": "direction",
+            "pattern": "dir-([a-zA-Z0-9]+)",
+            "aliases": ["dir"]
+        },
+        {
+            "name": "run",
+            "pattern": "run-(\\d+)"
+        },
+        {
+            "name": "mod",
+            "pattern": "mod-([a-zA-Z0-9]+)"
         },
         {
             "name": "echo",
             "pattern": "echo-([0-9]+)\\_bold."
         },
         {
-            "name": "acquisition",
-            "pattern": "acq-([a-zA-Z0-9]+)"
+            "name": "recording",
+            "pattern": "recording-([a-zA-Z0-9]+)"
         },
         {
-            "name": "acq",
-            "pattern": "acq-([a-zA-Z0-9]+)"
+            "name": "type",
+            "pattern": "[._]*([a-zA-Z0-9]*?)\\.[^/\\\\]+$"
+        },
+        {
+            "name": "scans",
+            "pattern": "(.*\\_scans.tsv)$"
         },
         {
             "name": "bval",
@@ -58,18 +79,6 @@
         {
             "name": "modality",
             "pattern": "[/\\\\](func|anat|fmap|dwi)[/\\\\]"
-        },
-        {
-            "name": "direction",
-            "pattern": "dir-([a-zA-Z0-9]+)"
-        },
-        {
-            "name": "dir",
-            "pattern": "dir-([a-zA-Z0-9]+)"
-        },
-        {
-            "name": "recording",
-            "pattern": "recording-([a-zA-Z0-9]+)"
         }
     ]
 }

--- a/bids/grabbids/config/bids.json
+++ b/bids/grabbids/config/bids.json
@@ -6,16 +6,14 @@
         {
             "name": "subject",
             "pattern": ".*sub-([a-zA-Z0-9]+)",
-            "directory": "{{root}}/{subject}",
-            "aliases": ["sub"]
+            "directory": "{{root}}/{subject}"
         },
         {
             "name": "session",
             "pattern": "ses-([a-zA-Z0-9]+)",
             "mandatory": false,
             "directory": "{{root}}/{subject}/{session}",
-            "missing_value": "ses-1",
-            "aliases": ["ses"]
+            "missing_value": "ses-1"
         },
         {
             "name": "task",
@@ -23,8 +21,11 @@
         },
         {
             "name": "acquisition",
-            "pattern": "acq-([a-zA-Z0-9]+)",
-            "aliases": ["acq"]
+            "pattern": "acq-([a-zA-Z0-9]+)"
+        },
+        {
+            "name": "acq",
+            "pattern": "acq-([a-zA-Z0-9]+)"
         },
         {
             "name": "ce",
@@ -32,13 +33,11 @@
         },
         {
             "name": "reconstruction",
-            "pattern": "rec-([a-zA-Z0-9]+)",
-            "aliases": ["rec"]
+            "pattern": "rec-([a-zA-Z0-9]+)"
         },
         {
-            "name": "direction",
-            "pattern": "dir-([a-zA-Z0-9]+)",
-            "aliases": ["dir"]
+            "name": "dir",
+            "pattern": "dir-([a-zA-Z0-9]+)"
         },
         {
             "name": "run",

--- a/bids/grabbids/config/bids.json
+++ b/bids/grabbids/config/bids.json
@@ -25,7 +25,7 @@
         },
         {
             "name": "task",
-            "pattern": "task-(.*?)(?:_+)"
+            "pattern": "task-([a-zA-Z0-9]+)"
         },
         {
             "name": "scans",
@@ -37,7 +37,11 @@
         },
         {
             "name": "acquisition",
-            "pattern": "acq-(.*?)(?:_+)"
+            "pattern": "acq-([a-zA-Z0-9]+)"
+        },
+        {
+            "name": "acq",
+            "pattern": "acq-([a-zA-Z0-9]+)"
         },
         {
             "name": "bval",
@@ -56,16 +60,16 @@
             "pattern": "[/\\\\](func|anat|fmap|dwi)[/\\\\]"
         },
         {
+            "name": "direction",
+            "pattern": "dir-([a-zA-Z0-9]+)"
+        },
+        {
             "name": "dir",
             "pattern": "dir-([a-zA-Z0-9]+)"
         },
         {
             "name": "recording",
             "pattern": "recording-([a-zA-Z0-9]+)"
-        },
-        {
-            "name": "acq",
-            "pattern": "acq-([a-zA-Z0-9]+)"
         }
     ]
 }


### PR DESCRIPTION
We had a duplicate of `acq` and `acquisition`. Talking with @tyarkoni and @chrisfilo, we decided we should support both, but use aliases (grabbles/grabbit#39) to reduce duplication. Further, it was decided the entity short name (e.g. "ses" for "session") should be available for users, so aliases were added for all such entities.

The remaining unimplemented entities ("ce", "rec" and "mod") were added, and reordered to keep the standard entities together.