### PR TITLE
Grabbids updates: Path patterns, regex matches, custom extensions

### DIFF
--- a/bids/grabbids/bids_layout.py
+++ b/bids/grabbids/bids_layout.py
@@ -30,9 +30,12 @@ class BIDSLayout(Layout):
             with open(config) as fobj:
                 config = json.load(fobj)
         for ext in extensions or []:
-            with open(pathjoin(root, 'config', '%s.json' % ext)) as fobj:
+            builtin_ext = pathjoin(root, 'config', '%s.json' % ext)
+            if os.path.exists(builtin_ext):
+                ext = builtin_ext
+            with open(ext) as fobj:
                 ext_config = json.load(fobj)
-                config['entities'].extend(ext_config['entities'])
+            config['entities'].extend(ext_config['entities'])
 
         super(BIDSLayout, self).__init__(path, config=config,
                                          dynamic_getters=True, **kwargs)

--- a/bids/grabbids/config/bids.json
+++ b/bids/grabbids/config/bids.json
@@ -5,55 +5,55 @@
     "entities": [
         {
             "name": "subject",
-            "pattern": ".*sub-([a-zA-Z0-9]+)",
+            "pattern": "[_/\\\\]sub-([a-zA-Z0-9]+)",
             "directory": "{{root}}/{subject}"
         },
         {
             "name": "session",
-            "pattern": "ses-([a-zA-Z0-9]+)",
+            "pattern": "[_/\\\\]ses-([a-zA-Z0-9]+)",
             "mandatory": false,
             "directory": "{{root}}/{subject}/{session}",
             "missing_value": "ses-1"
         },
         {
             "name": "task",
-            "pattern": "task-([a-zA-Z0-9]+)"
+            "pattern": "[_/\\\\]task-([a-zA-Z0-9]+)"
         },
         {
             "name": "acquisition",
-            "pattern": "acq-([a-zA-Z0-9]+)"
+            "pattern": "[_/\\\\]acq-([a-zA-Z0-9]+)"
         },
         {
             "name": "acq",
-            "pattern": "acq-([a-zA-Z0-9]+)"
+            "pattern": "[_/\\\\]acq-([a-zA-Z0-9]+)"
         },
         {
             "name": "ce",
-            "pattern": "ce-([a-zA-Z0-9]+)"
+            "pattern": "[_/\\\\]ce-([a-zA-Z0-9]+)"
         },
         {
             "name": "reconstruction",
-            "pattern": "rec-([a-zA-Z0-9]+)"
+            "pattern": "[_/\\\\]rec-([a-zA-Z0-9]+)"
         },
         {
             "name": "dir",
-            "pattern": "dir-([a-zA-Z0-9]+)"
+            "pattern": "[_/\\\\]dir-([a-zA-Z0-9]+)"
         },
         {
             "name": "run",
-            "pattern": "run-(\\d+)"
+            "pattern": "[_/\\\\]run-(\\d+)"
         },
         {
             "name": "mod",
-            "pattern": "mod-([a-zA-Z0-9]+)"
+            "pattern": "[_/\\\\]mod-([a-zA-Z0-9]+)"
         },
         {
             "name": "echo",
-            "pattern": "echo-([0-9]+)\\_bold."
+            "pattern": "[_/\\\\]echo-([0-9]+)\\_bold."
         },
         {
             "name": "recording",
-            "pattern": "recording-([a-zA-Z0-9]+)"
+            "pattern": "[_/\\\\]recording-([a-zA-Z0-9]+)"
         },
         {
             "name": "type",

--- a/bids/grabbids/config/bids.json
+++ b/bids/grabbids/config/bids.json
@@ -5,7 +5,7 @@
     "entities": [
         {
             "name": "subject",
-            "pattern": "[_/\\\\]sub-([a-zA-Z0-9]+)",
+            "pattern": "[/\\\\]sub-([a-zA-Z0-9]+)",
             "directory": "{{root}}/{subject}"
         },
         {

--- a/bids/grabbids/config/bids.json
+++ b/bids/grabbids/config/bids.json
@@ -1,6 +1,7 @@
 {
     "index" : {
-      "exclude" : [".*derivatives$", ".*models$", ".*sourcedata$", ".*code$"]
+      "exclude" : [".*derivatives$", ".*models$", ".*sourcedata$", ".*code$",
+                   "^\\.", ".*[/\\\\]\\."]
     },
     "entities": [
         {

--- a/bids/grabbids/config/bids.json
+++ b/bids/grabbids/config/bids.json
@@ -81,11 +81,11 @@
         }
     ],
     "default_path_patterns": [
-        "sub-{subject}[/ses-{session}]/anat/sub-{subject}[_ses-{session}][_acq-{acquisition}][_ce-{contrast}][_rec-{reconstruction}]_{type}",
-        "sub-{subject}[/ses-{session}]/anat/sub-{subject}[_ses-{session}][_acq-{acquisition}][_ce-{contrast}][_rec-{reconstruction}][_mod-{modality}]_defacemask",
-        "sub-{subject}[/ses-{session}]/func/sub-{subject}[_ses-{session}][_task-{task}][_acq-{acquisition}][_rec-{reconstruction}][_run-{run}][_echo-{echo}]_{type}",
-        "sub-{subject}[/ses-{session}]/dwi/sub-{subject}[_ses-{session}][_acq-{acquisition}]_{type}",
-        "sub-{subject}[/ses-{session}]/fmap/sub-{subject}[_ses-{session}][_acq-{acquisition}][_dir-{direction}][_run-{run}]_{type}",
-        "sub-{subject}[/ses-{session}]/func/sub-{subject}[_ses-{session}][_task-{task}][_acq-{acquisition}][_rec-{reconstruction}][_run-{run}][_echo-{echo}][_recording-{recording}]_physio.tsv"
+        "sub-{subject}[/ses-{session}]/anat/sub-{subject}[_ses-{session}][_acq-{acquisition}][_ce-{contrast}][_rec-{reconstruction}]_{type}.nii.gz",
+        "sub-{subject}[/ses-{session}]/anat/sub-{subject}[_ses-{session}][_acq-{acquisition}][_ce-{contrast}][_rec-{reconstruction}][_mod-{modality}]_defacemask.nii.gz",
+        "sub-{subject}[/ses-{session}]/func/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_rec-{reconstruction}][_run-{run}][_echo-{echo}]_{type}.nii.gz",
+        "sub-{subject}[/ses-{session}]/dwi/sub-{subject}[_ses-{session}][_acq-{acquisition}]_{type}.nii.gz",
+        "sub-{subject}[/ses-{session}]/fmap/sub-{subject}[_ses-{session}][_acq-{acquisition}][_dir-{direction}][_run-{run}]_{type}.nii.gz",
+        "sub-{subject}[/ses-{session}]/func/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_rec-{reconstruction}][_run-{run}][_echo-{echo}][_recording-{recording}]_physio.tsv"
     ]
 }


### PR DESCRIPTION
Pulls three fixes out of #110:

* Path patterns are updated to make task required and include .nii.gz extensions
* Parsing patterns require that the entity key be preceded with `_` or `/`, to avoid conflicts when one entity is the suffix of another (e.g., `ce` and `space` from the derivatives extension).
* Allows extensions to be valid filenames, which permits downstream software to package their own extensions

Does not update path patterns to condition entity values, as that's unreleased grabbit behavior at present.