### PR TITLE
ENH: Fix factor transform to produce variables of same length, enable boolean transforms

### DIFF
--- a/bids/analysis/analysis.py
+++ b/bids/analysis/analysis.py
@@ -468,6 +468,8 @@ def apply_transformations(collection, transformations, select=None):
         cols = kwargs.pop('input', None)
 
         if isinstance(func, string_types):
+            if func in ('and', 'or'):
+                func += '_'
             if not hasattr(transform, func):
                 raise ValueError("No transformation '%s' found!" % func)
             func = getattr(transform, func)

--- a/bids/analysis/tests/test_transformations.py
+++ b/bids/analysis/tests/test_transformations.py
@@ -202,10 +202,54 @@ def test_regex_variable_expansion(collection):
 
 
 def test_factor(collection):
-    transform.factor(collection, 'trial_type', sep='@')
-    assert 'trial_type@parametric gain' in collection.variables.keys()
-    pg = collection.variables['trial_type@parametric gain']
+    # Full-rank dummy-coding, only one unique value in variable
+    trial_type = collection.variables['trial_type'].clone()
+    coll = collection.clone()
+    transform.factor(coll, 'trial_type', sep='@')
+    assert 'trial_type@parametric gain' in coll.variables.keys()
+    pg = coll.variables['trial_type@parametric gain']
     assert pg.values.unique() == [1]
+    assert pg.values.shape == trial_type.values.shape
+
+    # Reduced-rank dummy-coding, only one unique value in variable
+    coll = collection.clone()
+    transform.factor(coll, 'trial_type', constraint='mean_zero')
+    assert 'trial_type.parametric gain' in coll.variables.keys()
+    pg = coll.variables['trial_type.parametric gain']
+    assert pg.values.unique() == [1]
+    assert pg.values.shape == trial_type.values.shape
+
+    # full-rank dummy-coding, multiple values
+    coll = collection.clone()
+    transform.factor(coll, 'respnum')
+    targets = set(['respnum.%d' % d for d in range(0, 5)])
+    assert not targets - set(coll.variables.keys())
+    assert all([set(coll.variables[t].values.unique()) == {0.0, 1.0}
+                for t in targets])
+    data = pd.concat([coll.variables[t].values for t in targets], axis=1)
+    assert (data.sum(1) == 1).all()
+
+    # reduced-rank dummy-coding, multiple values
+    coll = collection.clone()
+    transform.factor(coll, 'respnum', constraint='drop_one')
+    targets = set(['respnum.%d' % d for d in range(1, 5)])
+    assert not targets - set(coll.variables.keys())
+    assert 'respnum.0' not in coll.variables.keys()
+    assert all([set(coll.variables[t].values.unique()) == {0.0, 1.0}
+                for t in targets])
+    data = pd.concat([coll.variables[t].values for t in targets], axis=1)
+    assert set(np.unique(data.sum(1).values.ravel())) == {0., 1.}
+
+    # Effect coding, multiple values
+    coll = collection.clone()
+    transform.factor(coll, 'respnum', constraint='mean_zero')
+    targets = set(['respnum.%d' % d for d in range(1, 5)])
+    assert not targets - set(coll.variables.keys())
+    assert 'respnum.0' not in coll.variables.keys()
+    assert all([set(coll.variables[t].values.unique()) == {-0.25, 0.0, 1.0}
+                for t in targets])
+    data = pd.concat([coll.variables[t].values for t in targets], axis=1)
+    assert set(np.unique(data.sum(1).values.ravel())) == {-1., 1.}
 
 
 def test_filter(collection):

--- a/bids/analysis/tests/test_transformations.py
+++ b/bids/analysis/tests/test_transformations.py
@@ -276,3 +276,29 @@ def test_select(collection):
     keep = ['RT', 'parametric gain', 'respcat']
     transform.select(collection, keep)
     assert set(collection.variables.keys()) == set(keep)
+
+
+def test_and(collection):
+    coll = collection.clone()
+    transform.factor(coll, 'respnum')
+    names = ['respnum.%d' % d for d in range(0, 5)]
+    transform.and_(coll, names, output='conjunction')
+    assert not coll.variables['conjunction'].values.sum()
+
+    coll['copy'] = coll.variables['respnum.0'].clone()
+    transform.and_(coll, ['respnum.0', 'copy'], output='conj')
+    assert coll.variables['conj'].values.astype(float).equals(
+        coll.variables['respnum.0'].values)
+
+
+def test_or(collection):
+    coll = collection.clone()
+    transform.factor(coll, 'respnum')
+    names = ['respnum.%d' % d for d in range(0, 5)]
+    transform.or_(coll, names, output='disjunction')
+    assert (coll.variables['disjunction'].values == 1).all()
+
+    coll['copy'] = coll.variables['respnum.0'].clone()
+    transform.or_(coll, ['respnum.0', 'copy'], output='or')
+    assert coll.variables['or'].values.astype(float).equals(
+        coll.variables['respnum.0'].values)

--- a/bids/analysis/transformations/__init__.py
+++ b/bids/analysis/transformations/__init__.py
@@ -5,6 +5,7 @@ __all__ = [
     'sum',
     'product',
     'and_',
+    'or_',
     'scale',
     'orthogonalize',
     'threshold',

--- a/bids/analysis/transformations/__init__.py
+++ b/bids/analysis/transformations/__init__.py
@@ -1,9 +1,10 @@
-from .compute import (sum, product, scale, orthogonalize, threshold)
+from .compute import (sum, product, scale, orthogonalize, threshold, and_)
 from .munge import (split, rename, assign, copy, factor, filter, select)
 
 __all__ = [
     'sum',
     'product',
+    'and_',
     'scale',
     'orthogonalize',
     'threshold',

--- a/bids/analysis/transformations/__init__.py
+++ b/bids/analysis/transformations/__init__.py
@@ -1,4 +1,4 @@
-from .compute import (sum, product, scale, orthogonalize, threshold, and_)
+from .compute import (sum, product, scale, orthogonalize, threshold, and_, or_)
 from .munge import (split, rename, assign, copy, factor, filter, select)
 
 __all__ = [

--- a/bids/analysis/transformations/base.py
+++ b/bids/analysis/transformations/base.py
@@ -250,9 +250,7 @@ class Transformation(object):
             # If we still have a list, pass all variables in one block
             if isinstance(col, (list, tuple)):
                 result = self._transform(data, **kwargs)
-                if self._return_type == 'variable':
-                    result = result.clone(name=self.output[0])
-                elif self._return_type not in ['none', None]:
+                if self._return_type not in ['none', None]:
                     col = col[0].clone(data=result, name=self.output[0])
             # Otherwise loop over variables individually
             else:

--- a/bids/analysis/transformations/base.py
+++ b/bids/analysis/transformations/base.py
@@ -250,7 +250,9 @@ class Transformation(object):
             # If we still have a list, pass all variables in one block
             if isinstance(col, (list, tuple)):
                 result = self._transform(data, **kwargs)
-                if self._return_type not in ['none', None]:
+                if self._return_type == 'variable':
+                    result = result.clone(name=self.output[0])
+                elif self._return_type not in ['none', None]:
                     col = col[0].clone(data=result, name=self.output[0])
             # Otherwise loop over variables individually
             else:

--- a/bids/analysis/transformations/compute.py
+++ b/bids/analysis/transformations/compute.py
@@ -118,7 +118,7 @@ class or_(Transformation):
 
     def _transform(self, dfs):
         df = pd.concat(dfs, axis=1)
-        return df.any(axis=1)
+        return df.any(axis=1).astype(int)
 
 
 class and_(Transformation):
@@ -133,4 +133,4 @@ class and_(Transformation):
 
     def _transform(self, dfs):
         df = pd.concat(dfs, axis=1)
-        return df.all(axis=1)
+        return df.all(axis=1).astype(int)

--- a/bids/analysis/transformations/compute.py
+++ b/bids/analysis/transformations/compute.py
@@ -6,7 +6,6 @@ import numpy as np
 import pandas as pd
 from bids.utils import listify
 from .base import Transformation
-from ...variables import SparseRunVariable
 
 
 class scale(Transformation):
@@ -128,32 +127,10 @@ class and_(Transformation):
         dfs (list of DFs): variables to enter into the conjunction.
     '''
 
-    _input_type = 'variable'
-    _return_type = 'variable'
     _loopable = False
     _groupable = False
     _output_required = True
 
-    def _transform(self, var):
-        if isinstance(var[0], SparseRunVariable):
-            onset = var[0].onset
-            for v in var[1:]:
-                onset = onset[np.in1d(onset, v.onset)]
-
-            selector = np.in1d(var[0].onset, onset)
-            duration = var[0].duration[selector]
-            values = var[0].values[selector]
-            for v in var:
-                selector = np.in1d(v.onset, onset)
-                if not (np.allclose(duration, v.duration[selector]) and
-                        np.allclose(values, v.values[selector])):
-                    raise ValueError("Mismatched onset/duration/weights")
-            return SparseRunVariable(
-                var[0].name,
-                pd.DataFrame({'onset': onset, 'duration': duration,
-                              'amplitude': values}),
-                run_info = var[0].run_info,
-                source = var[0].run_info)
-
-        df = pd.concat(var, axis=1)
+    def _transform(self, dfs):
+        df = pd.concat(dfs, axis=1)
         return df.all(axis=1)

--- a/bids/analysis/transformations/munge.py
+++ b/bids/analysis/transformations/munge.py
@@ -197,7 +197,7 @@ class factor(Transformation):
                 continue
             name = ''.join([var.name, sep, str(lev)])
             lev_data = data.copy()
-            lev_data['amplitude'] = new_cols[lev]
+            lev_data['amplitude'] = new_cols[lev].astype(float)
             args = [name, lev_data, var.source]
             if hasattr(var, 'run_info'):
                 args.insert(2, var.run_info)

--- a/bids/analysis/transformations/munge.py
+++ b/bids/analysis/transformations/munge.py
@@ -3,6 +3,7 @@ Transformations that primarily involve manipulating/munging variables into
 other formats or shapes.
 '''
 
+import numpy as np
 import pandas as pd
 from bids.utils import listify
 from .base import Transformation
@@ -176,27 +177,28 @@ class factor(Transformation):
 
         result = []
         data = var.to_df()
-        grps = data.groupby('amplitude')
         orig_name = var.name
         variableClass = var.__class__
 
-        # Determine the reference level
-        if constraint in ['drop_one', 'mean_zero']:
-            levels = data['amplitude'].unique().sort_values()
+        levels = np.sort(data['amplitude'].unique())
+        new_cols = pd.get_dummies(data['amplitude'], drop_first=False)[levels]
+
+        if len(levels) > 1 and constraint in ('drop_one', 'mean_zero'):
             if ref_level is None:
                 ref_level = levels[0]
+            new_cols = new_cols.drop(ref_level, axis=1)
 
-        for i, (lev_name, lev_grp) in enumerate(grps):
-            # TODO: consider appending info about the constraint to the name,
-            # though this has the downside of making names very long and
-            # difficult to work with.
-            name = ''.join([var.name, sep, lev_name])
-            # TODO: implement constraint == 'mean_zero'
-            if constraint == 'drop_one' and lev_name == ref_level:
+            if constraint == 'mean_zero':
+                ref_inds = data['amplitude'] == ref_level
+                new_cols.loc[ref_inds, :] = -1. / (len(levels) - 1)
+
+        for lev in levels:
+            if ref_level is not None and lev == ref_level:
                 continue
-            lev_grp['amplitude'] = 1.0
-
-            args = [name, lev_grp, var.source]
+            name = ''.join([var.name, sep, str(lev)])
+            lev_data = data.copy()
+            lev_data['amplitude'] = new_cols[lev]
+            args = [name, lev_data, var.source]
             if hasattr(var, 'run_info'):
                 args.insert(2, var.run_info)
             new_col = variableClass(*args)


### PR DESCRIPTION
Addresses #127.

Currently modifying input models to use `"and_"` instead of `"and"`.

Approach is to verify that onsets, durations and amplitudes match before taking the intersection.