### PR TITLE
Grabbit fixes

### DIFF
--- a/bids/analysis/tests/test_analysis.py
+++ b/bids/analysis/tests/test_analysis.py
@@ -9,7 +9,7 @@ import pytest
 @pytest.fixture
 def analysis():
     layout_path = join(get_test_data_path(), 'ds005')
-    layout = BIDSLayout(layout_path)
+    layout = BIDSLayout(layout_path, exclude='derivatives/')
     json_file = join(layout_path, 'models', 'ds-005_type-test_model.json')
     analysis = Analysis(layout, json_file)
     analysis.setup(scan_length=480, subject=['01', '02'])

--- a/bids/analysis/tests/test_transformations.py
+++ b/bids/analysis/tests/test_transformations.py
@@ -11,7 +11,7 @@ import pandas as pd
 @pytest.fixture
 def collection():
     layout_path = join(get_test_data_path(), 'ds005')
-    layout = BIDSLayout(layout_path)
+    layout = BIDSLayout(layout_path, exclude='derivatives/')
     collection = layout.get_collections('run', types=['events'],
                                         scan_length=480, merge=True,
                                         sampling_rate=10)

--- a/bids/grabbids/bids_layout.py
+++ b/bids/grabbids/bids_layout.py
@@ -200,8 +200,8 @@ class BIDSLayout(Layout):
         sub = os.path.split(path)[1].split("_")[0].split("sub-")[1]
         fieldmap_set = []
         type_ = '(phase1|phasediff|epi|fieldmap)'
-        for file in self.get(subject=sub, type=type_,
-                             extensions=['nii.gz', 'nii']):
+        files = self.get(subject=sub, type=type_, extensions=['nii.gz', 'nii'])
+        for file in files:
             metadata = self.get_metadata(file.filename)
             if metadata and "IntendedFor" in metadata.keys():
                 if isinstance(metadata["IntendedFor"], list):

--- a/bids/grabbids/bids_layout.py
+++ b/bids/grabbids/bids_layout.py
@@ -39,9 +39,11 @@ class BIDSLayout(Layout):
             At present, built-in domains include 'bids' and 'derivatives'.
 
         validate (bool): If True, all files are checked for BIDS compliance
-            when first indexed, and non-compliant files are ignored. Note that
-            the validator is experimental and may fail to perfectly detect
-            compliance.
+            when first indexed, and non-compliant files are ignored. This
+            provides a convenient way to restrict file indexing to only those
+            files defined in the "core" BIDS spec, as setting validate=True
+            will lead files in supplementary folders like derivatives/, code/,
+            etc. to be ignored.
         index_associated (bool): Argument passed onto the BIDSValidator;
             ignored if validate = False.
         include (str, list): String or list of strings giving paths to files or

--- a/bids/grabbids/config/bids.json
+++ b/bids/grabbids/config/bids.json
@@ -1,10 +1,6 @@
 {
     "name": "bids",
     "root": ".",
-    "index" : {
-      "exclude" : [".*derivatives$", ".*models$", ".*sourcedata$", ".*code$",
-                   "^\\.", ".*[/\\\\]\\."]
-    },
     "entities": [
         {
             "name": "subject",

--- a/bids/grabbids/config/bids.json
+++ b/bids/grabbids/config/bids.json
@@ -1,4 +1,6 @@
 {
+    "name": "bids",
+    "root": ".",
     "index" : {
       "exclude" : [".*derivatives$", ".*models$", ".*sourcedata$", ".*code$",
                    "^\\.", ".*[/\\\\]\\."]

--- a/bids/grabbids/config/derivatives.json
+++ b/bids/grabbids/config/derivatives.json
@@ -1,6 +1,5 @@
 {
     "name": "derivatives",
-    "root": "derivatives",
     "entities": [
         {
             "name": "target",

--- a/bids/grabbids/config/derivatives.json
+++ b/bids/grabbids/config/derivatives.json
@@ -1,4 +1,6 @@
 {
+    "name": "derivatives",
+    "root": "derivatives",
     "entities": [
         {
             "name": "target",

--- a/bids/grabbids/tests/test_grabbids.py
+++ b/bids/grabbids/tests/test_grabbids.py
@@ -103,7 +103,7 @@ def test_get_events(testmergedlayout):
 def test_get_events2(testlayout2):
     target = 'sub-03/anat/sub-03_T1w.nii.gz'
     result = testlayout2.get_events(join(testlayout2.root, target))
-    assert result == None
+    assert result is None
 
 
 def test_get_bvals_bvecs(testlayout2):

--- a/bids/grabbids/tests/test_grabbids.py
+++ b/bids/grabbids/tests/test_grabbids.py
@@ -8,30 +8,22 @@ from bids.tests import get_test_data_path
 
 
 # Fixture uses in the rest of the tests
-@pytest.fixture
+@pytest.fixture(scope='module')
 def testlayout1():
     data_dir = join(get_test_data_path(), '7t_trt')
     return BIDSLayout(data_dir)
 
 
-@pytest.fixture
+@pytest.fixture(scope='module')
 def testlayout2():
     data_dir = join(get_test_data_path(), 'ds005')
-    return BIDSLayout(data_dir)
+    return BIDSLayout(data_dir, exclude=['models/', 'derivatives/'])
 
 
-@pytest.fixture
+@pytest.fixture(scope='module')
 def testlayout3():
     data_dir = join(get_test_data_path(), 'ds005')
     return BIDSLayout(data_dir, config=['bids', 'derivatives'])
-
-
-@pytest.fixture
-def testmergedlayout():
-    data_dir = [join(get_test_data_path(), 'ds005'),
-                join(get_test_data_path(), 'ds005',
-                     'derivatives', 'events')]
-    return BIDSLayout(data_dir)
 
 
 def test_layout_init(testlayout1):
@@ -76,20 +68,20 @@ def test_get_metadata5(testlayout1):
     assert result['acquisition'] == 'fullbrain'
 
 
-def test_get_events(testmergedlayout):
+def test_get_events(testlayout3):
     target = 'sub-01/func/sub-01_task-' \
              'mixedgamblestask_run-01_bold.nii.gz'
-    result = testmergedlayout.get_events(join(testmergedlayout.root, target))
+    result = testlayout3.get_events(join(testlayout3.root, target))
     assert len(result) == 2
     expected1 = abspath(join(
-        testmergedlayout.root, target.replace('_bold.nii.gz', '_events.tsv')))
+        testlayout3.root, target.replace('_bold.nii.gz', '_events.tsv')))
     assert expected1 in result
 
     expected2 = abspath(join(
-        testmergedlayout.root, 'derivatives/events/', basename(expected1)))
+        testlayout3.root, 'derivatives/events/', basename(expected1)))
 
-    merged = testmergedlayout.get_events(join(testmergedlayout.root, target),
-                                         return_type='df')
+    merged = testlayout3.get_events(join(testlayout3.root, target),
+                                    return_type='df')
 
     assert 'response' in merged
     assert 'trial_type' in merged
@@ -157,3 +149,7 @@ def test_layout_with_derivs(testlayout3):
     assert 'derivatives.roi' in testlayout3.entities
     assert 'bids.roi' not in testlayout3.entities
     assert 'bids.subject' in testlayout3.entities
+
+
+def test_layout_with_custom_domain_options():
+    pass

--- a/bids/grabbids/tests/test_grabbids.py
+++ b/bids/grabbids/tests/test_grabbids.py
@@ -21,17 +21,17 @@ def testlayout2():
 
 
 @pytest.fixture
+def testlayout3():
+    data_dir = join(get_test_data_path(), 'ds005')
+    return BIDSLayout(data_dir, config=['bids', 'derivatives'])
+
+
+@pytest.fixture
 def testmergedlayout():
     data_dir = [join(get_test_data_path(), 'ds005'),
                 join(get_test_data_path(), 'ds005',
                      'derivatives', 'events')]
     return BIDSLayout(data_dir)
-
-
-@pytest.fixture
-def testlayout3():
-    data_dir = join(get_test_data_path(), 'ds005')
-    return BIDSLayout(data_dir, extensions=['derivatives'])
 
 
 def test_layout_init(testlayout1):
@@ -151,3 +151,9 @@ def test_exclude(testlayout2):
 
 def test_layout_with_derivs(testlayout3):
     assert isinstance(testlayout3.files, dict)
+    assert set(testlayout3.domains.keys()) == {'bids', 'derivatives'}
+    assert testlayout3.domains['bids'].files
+    assert testlayout3.domains['derivatives'].files
+    assert 'derivatives.roi' in testlayout3.entities
+    assert 'bids.roi' not in testlayout3.entities
+    assert 'bids.subject' in testlayout3.entities

--- a/bids/grabbids/utils.py
+++ b/bids/grabbids/utils.py
@@ -26,7 +26,7 @@ def _merge_event_files(events):
                 keep_key = key[:-len(conf_suff)]
                 merged[keep_key] = merged[keep_key].combine_first(merged[key])
 
-            merged = merged.drop(columns=clash_keys)
+            merged = merged.drop(clash_keys, axis=1)
 
             return merged
 

--- a/bids/variables/tests/test_collections.py
+++ b/bids/variables/tests/test_collections.py
@@ -8,7 +8,7 @@ from bids.variables import DenseRunVariable, merge_collections
 @pytest.fixture(scope="module")
 def run_coll():
     path = join(get_test_data_path(), 'ds005')
-    layout = BIDSLayout(path)
+    layout = BIDSLayout(path, exclude='derivatives/')
     return layout.get_collections('run', types=['events'], merge=True,
                                   scan_length=480)
 
@@ -16,7 +16,7 @@ def run_coll():
 @pytest.fixture(scope="module")
 def run_coll_list():
     path = join(get_test_data_path(), 'ds005')
-    layout = BIDSLayout(path)
+    layout = BIDSLayout(path, exclude='derivatives/')
     return layout.get_collections('run', types=['events'], merge=False,
                                   scan_length=480)
 

--- a/bids/variables/tests/test_entities.py
+++ b/bids/variables/tests/test_entities.py
@@ -10,7 +10,7 @@ from bids.tests import get_test_data_path
 @pytest.fixture(scope="module")
 def layout1():
     path = join(get_test_data_path(), 'ds005')
-    layout = BIDSLayout(path)
+    layout = BIDSLayout(path, exclude='derivatives/')
     return layout
 
 

--- a/bids/variables/tests/test_io.py
+++ b/bids/variables/tests/test_io.py
@@ -10,14 +10,14 @@ from bids.tests import get_test_data_path
 @pytest.fixture
 def layout1():
     path = join(get_test_data_path(), 'ds005')
-    layout = BIDSLayout(path)
+    layout = BIDSLayout(path, exclude='derivatives/')
     return layout
 
 
 @pytest.fixture(scope="module")
 def synthetic():
     path = join(get_test_data_path(), 'synthetic')
-    layout = BIDSLayout(path)
+    layout = BIDSLayout(path, exclude='derivatives/')
     return load_variables(layout)
 
 

--- a/bids/variables/tests/test_variables.py
+++ b/bids/variables/tests/test_variables.py
@@ -23,7 +23,7 @@ def generate_DEV(name='test', sr=20, duration=480):
 @pytest.fixture
 def layout1():
     path = join(get_test_data_path(), 'ds005')
-    layout = BIDSLayout(path)
+    layout = BIDSLayout(path, exclude='derivatives/')
     return layout
 
 

--- a/bids/version.py
+++ b/bids/version.py
@@ -65,7 +65,7 @@ MICRO = _version_micro
 VERSION = __version__
 # No data for now
 # PACKAGE_DATA = {'bids': [pjoin('data', '*')]}
-REQUIRES = ["grabbit>=0.1.0", "six"]
+REQUIRES = ["grabbit>=0.1.1", "six"]
 EXTRAS_REQUIRE = {
     'analysis': ['numpy', 'scipy', 'pandas', 'nibabel', 'patsy'],
 }


### PR DESCRIPTION
This PR patches pybids to be compatible with recent changes to grabbit. The main change is the addition of a new `name` field to the JSON config files, which is now mandatory in grabbit in order to support named domain functionality. Handling of derivatives is also modified to fit with grabbit's ability to handle hierarchical specifications. These changes should be fully backwards compatible for the vast majority of users. (The exception being specification of the `extensions` argument in the `BIDSLayout` init, as that argument is now removed. But I'd be very surprised if anyone's using that in the wild, as we only recently added it as a stopgap measure until the now-committed grabbit changes).

TODO: grabbit entity specifications now support a `dtype` field, so we should probably make a pass through `bids.json` and add the appropriate dtypes everywhere.