### PR TITLE
Packaging fixes

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,5 +3,6 @@ branch = True
 source = bids/*
 include = bids/*
 omit = */setup.py
+
 [report]
 include = bids/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,12 +39,10 @@ before_install:
 - conda install --quiet python=$PYTHON_VERSION $CONDA_DEPS
 
 install:
-- pip install -e ".[analysis]"
-- pip install --upgrade git+https://github.com/grabbles/grabbit.git
+- pip install ".[analysis]"
 
 script:
-# - flake8 --ignore N802,N806 `find . -name \*.py | grep -v setup.py | grep -v /doc/`
-- py.test --pyargs bids
+- py.test
 
 after_success:
 - coveralls

--- a/bids/version.py
+++ b/bids/version.py
@@ -69,3 +69,8 @@ REQUIRES = ["grabbit>=0.1.1", "six", "num2words"]
 EXTRAS_REQUIRE = {
     'analysis': ['numpy', 'scipy', 'pandas', 'nibabel', 'patsy'],
 }
+TESTS_REQUIRE = ["pytest>=3.3.0"]
+PACKAGE_DATA = {
+    'bids.grabbids': ['grabbids/config/*.json'],
+    'bids.reports': ['reports/config/*.json']
+}

--- a/bids/version.py
+++ b/bids/version.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import, division, print_function
+import os
 
 # Format expected by setup.py and doc/source/conf.py: string of form "X.Y.Z"
 _version_major = 0
@@ -64,13 +65,24 @@ MINOR = _version_minor
 MICRO = _version_micro
 VERSION = __version__
 # No data for now
-# PACKAGE_DATA = {'bids': [pjoin('data', '*')]}
 REQUIRES = ["grabbit>=0.1.1", "six", "num2words"]
 EXTRAS_REQUIRE = {
     'analysis': ['numpy', 'scipy', 'pandas', 'nibabel', 'patsy'],
 }
 TESTS_REQUIRE = ["pytest>=3.3.0"]
+
+
+def package_files(directory):
+    # from https://stackoverflow.com/questions/27664504/how-to-add-package-data-recursively-in-python-setup-py
+    paths = []
+    for (path, directories, filenames) in os.walk(directory):
+        for filename in filenames:
+            paths.append(os.path.join('..', path, filename))
+    return paths
+
+extra_files = package_files('path_to/extra_files_dir')
 PACKAGE_DATA = {
-    'bids.grabbids': ['grabbids/config/*.json'],
-    'bids.reports': ['reports/config/*.json']
+    'bids.grabbids': ['config/*.json'],
+    'bids.reports': ['config/*.json'],
+    'bids': package_files('bids/tests/data')
 }

--- a/setup.py
+++ b/setup.py
@@ -23,9 +23,10 @@ opts = dict(name=NAME,
             platforms=PLATFORMS,
             version=VERSION,
             packages=PACKAGES,
-            package_data={'bids': ['grabbids/config/*.json']},
+            package_data=PACKAGE_DATA,
             install_requires=REQUIRES,
-            extras_require=EXTRAS_REQUIRE)
+            extras_require=EXTRAS_REQUIRE,
+            tests_require=TESTS_REQUIRE)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Data packaging was broken, but we didn't notice because pip was installing in editable mode on travis. This patches setup to install all data files, and also changes the travis config so pip installs normally. Fixes #138 and #143.