### PR TITLE
load and validate dataset_description.json; closes #151

### DIFF
--- a/bids/grabbids/bids_layout.py
+++ b/bids/grabbids/bids_layout.py
@@ -3,8 +3,7 @@ import json
 import warnings
 from io import open
 
-from os.path import dirname
-from os.path import abspath
+from os.path import dirname, abspath, exists
 from os.path import join as pathjoin
 
 from .bids_validator import BIDSValidator
@@ -62,6 +61,19 @@ class BIDSLayout(Layout):
 
     def __init__(self, path, config=None, validate=False,
                  index_associated=True, include=None, exclude=None, **kwargs):
+
+        # Load and validate information in dataset_description.json
+        target = pathjoin(path, 'dataset_description.json')
+        if not exists(target):
+            raise ValueError("Mandatory 'dataset_description.json' file is "
+                             "missing from project root!")
+        self.description = json.load(open(target, 'r'))
+
+        for k in ['Name', 'BIDSVersion']:
+            if k not in self.description:
+                raise ValueError("Mandatory '%s' field missing from "
+                                 "dataset_description.json." % k)
+
         self.validator = BIDSValidator(index_associated=index_associated)
         self.validate = validate
 

--- a/bids/grabbids/tests/test_grabbids.py
+++ b/bids/grabbids/tests/test_grabbids.py
@@ -30,6 +30,16 @@ def test_layout_init(testlayout1):
     assert isinstance(testlayout1.files, dict)
 
 
+def test_load_description(testlayout1):
+    with pytest.raises(ValueError) as e:
+        data_dir = join(get_test_data_path(), 'images')
+        layout = BIDSLayout(data_dir)
+        assert e.value.message.startswith("Mandatory 'dataset_description'")
+    assert hasattr(testlayout1, 'description')
+    assert testlayout1.description['Name'] == '7t_trt'
+    assert testlayout1.description['BIDSVersion'] == "1.0.0rc3"
+
+
 def test_get_metadata(testlayout1):
     target = 'sub-03/ses-2/func/sub-03_ses-2_task-' \
              'rest_acq-fullbrain_run-2_bold.nii.gz'


### PR DESCRIPTION
Adds a `.description` field that contains the contents of `dataset_description.json`. Also nags and complains if the file is missing, or if it's present but lacks the mandatory fields `Name` or `BIDSVersion`.

p.s. STFU @choldgraf 