### PR TITLE
Scipy seems to be a core dependency

### DIFF
--- a/bids/version.py
+++ b/bids/version.py
@@ -65,9 +65,9 @@ MINOR = _version_minor
 MICRO = _version_micro
 VERSION = __version__
 # No data for now
-REQUIRES = ["grabbit>=0.1.1", "six", "num2words"]
+REQUIRES = ["grabbit>=0.1.1", "six", "num2words", 'scipy']
 EXTRAS_REQUIRE = {
-    'analysis': ['numpy', 'scipy', 'pandas', 'nibabel', 'patsy'],
+    'analysis': ['numpy', 'pandas', 'nibabel', 'patsy'],
 }
 TESTS_REQUIRE = ["pytest>=3.3.0"]
 


### PR DESCRIPTION
If I read things right, `scipy` is specified as a dependency of the `analysis` flavor only. However:

```
(Pdb) bids.get_collections(level='dataset')
*** ImportError: No module named 'scipy'
```

Should it get promoted, or is this "analysis"?