### PR TITLE
 CI: Pre-releases, Python versions, Codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,37 +5,42 @@ sudo: false
 cache:
   directories:
     - $HOME/.cache/pip
+
+python:
+  - 2.7
+  - 3.5
+  - 3.6
+  - 3.7
 env:
   global:
     - EXTRA_WHEELS="https://5cf40426d9f06eb7461d-6fe47d9331aba7cd62fc36c7196769e4.ssl.cf2.rackcdn.com"
     - PRE_WHEELS="https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com"
+  matrix:
     - EXTRA_PIP_FLAGS="--find-links=$EXTRA_WHEELS"
-    - PRE_PIP_FLAGS="--pre $EXTRA_PIP_FLAGS --find-links $PRE_WHEELS"
+    - EXTRA_PIP_FLAGS="--pre --find-links=$EXTRA_WHEELS --find-links $PRE_WHEELS"
 
 matrix:
   include:
     - os: osx
       language: generic
       env:
-         - PYTHON_VERSION=2.7
-         - MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda2-latest-MacOSX-x86_64.sh"
+        - PYTHON_VERSION=2.7
+        - MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda2-latest-MacOSX-x86_64.sh"
     - os: osx
       language: generic
       env:
-         - PYTHON_VERSION=3.5
-         - MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh"
-    - os: linux
-      python: 2.7
-    - os: linux
-      python: 3.5
-    - os: linux
-      python: 2.7
+        - PYTHON_VERSION=3.5
+        - MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh"
+    - os: osx
+      language: generic
       env:
-         - EXTRA_PIP_FLAGS="$PRE_PIP_FLAGS"
-    - os: linux
-      python: 3.5
+        - PYTHON_VERSION=3.6
+        - MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh"
+    - os: osx
+      language: generic
       env:
-         - EXTRA_PIP_FLAGS="$PRE_PIP_FLAGS"
+        - PYTHON_VERSION=3.7
+        - MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh"
 
 before_install:
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ cache:
     - $HOME/.cache/pip
 env:
   global:
-    - CONDA_DEPS="pip flake8 pytest numpy scipy"
     - EXTRA_WHEELS="https://5cf40426d9f06eb7461d-6fe47d9331aba7cd62fc36c7196769e4.ssl.cf2.rackcdn.com"
     - PRE_WHEELS="https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com"
     - EXTRA_PIP_FLAGS="--find-links=$EXTRA_WHEELS"
@@ -48,8 +47,7 @@ before_install:
         bash miniconda.sh -b -s -f -p $MINICONDA;
         conda config --set always_yes yes;
         conda info -a;
-        conda config --add channels conda-forge;
-        conda install --quiet python=$PYTHON_VERSION $CONDA_DEPS;
+        conda install --quiet python=$PYTHON_VERSION;
       fi
     - travis_retry pip install --upgrade pip
     - travis_retry pip install --upgrade virtualenv

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,11 @@ cache:
   directories:
     - $HOME/.cache/pip
 
+# python and global.matrix are crossed to create the base build matrix
 python:
   - 2.7
   - 3.5
   - 3.6
-  - 3.7
 env:
   global:
     - EXTRA_WHEELS="https://5cf40426d9f06eb7461d-6fe47d9331aba7cd62fc36c7196769e4.ssl.cf2.rackcdn.com"
@@ -19,6 +19,7 @@ env:
     - EXTRA_PIP_FLAGS="--find-links=$EXTRA_WHEELS"
     - EXTRA_PIP_FLAGS="--pre --find-links=$EXTRA_WHEELS --find-links $PRE_WHEELS"
 
+# Add OSX entries to the build matrix
 matrix:
   include:
     - os: osx
@@ -35,11 +36,6 @@ matrix:
       language: generic
       env:
         - PYTHON_VERSION=3.6
-        - MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh"
-    - os: osx
-      language: generic
-      env:
-        - PYTHON_VERSION=3.7
         - MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh"
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,15 @@ env:
 matrix:
   include:
     - os: osx
-      python: 2.7
+      language: generic
+      env:
+         - PYTHON_VERSION=2.7
+         - MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda2-latest-MacOSX-x86_64.sh"
     - os: osx
-      python: 3.5
+      language: generic
+      env:
+         - PYTHON_VERSION=3.5
+         - MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh"
     - os: linux
       python: 2.7
     - os: linux
@@ -33,6 +39,18 @@ matrix:
          - EXTRA_PIP_FLAGS="$PRE_PIP_FLAGS"
 
 before_install:
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+        export MINICONDA=$HOME/miniconda;
+        export PATH="$MINICONDA/bin:$PATH";
+        hash -r;
+        echo $MINICONDA_URL;
+        wget $MINICONDA_URL -O miniconda.sh;
+        bash miniconda.sh -b -s -f -p $MINICONDA;
+        conda config --set always_yes yes;
+        conda info -a;
+        conda config --add channels conda-forge;
+        conda install --quiet python=$PYTHON_VERSION $CONDA_DEPS;
+      fi
     - travis_retry pip install --upgrade pip
     - travis_retry pip install --upgrade virtualenv
     - virtualenv --python=python venv

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ install:
 - pip install $EXTRA_PIP_FLAGS ".[analysis]"
 
 script:
-- py.test -n 2 -v --cov bids --cov-config .coveragerc --cov-report xml:cov.xml --doctest-modules bids
+- py.test -n 2 -v --cov bids --cov-config .coveragerc --cov-report xml:cov.xml bids
 
 after_script:
 - codecov --file cov.xml --flags unittests

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,13 +39,13 @@ before_install:
     - source venv/bin/activate
     - python --version # just to check
     - travis_retry pip install -U pip wheel  # needed at one point
-    - travis_retry pip install coveralls codecov
+    - travis_retry pip install pytest pytest-xdist coveralls codecov
 
 install:
 - pip install $EXTRA_PIP_FLAGS ".[analysis]"
 
 script:
-- py.test
+- py.test -n auto
 
 after_success:
 - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ install:
 - pip install $EXTRA_PIP_FLAGS ".[analysis]"
 
 script:
-- py.test -n auto
+- py.test -n 2
 
 after_success:
 - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,17 @@
+language: python
+
 sudo: false
 
+cache:
+  directories:
+    - $HOME/.cache/pip
 env:
   global:
     - CONDA_DEPS="pip flake8 pytest numpy scipy"
+    - EXTRA_WHEELS="https://5cf40426d9f06eb7461d-6fe47d9331aba7cd62fc36c7196769e4.ssl.cf2.rackcdn.com"
+    - PRE_WHEELS="https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com"
+    - EXTRA_PIP_FLAGS="--find-links=$EXTRA_WHEELS"
+    - PRE_PIP_FLAGS="--pre $EXTRA_PIP_FLAGS --find-links $PRE_WHEELS"
 
 matrix:
   include:
@@ -22,6 +31,16 @@ matrix:
       env:
          - PYTHON_VERSION=3.5
          - MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh"
+    - os: linux
+      env:
+         - PYTHON_VERSION=2.7
+         - MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh"
+         - EXTRA_PIP_FLAGS="$PRE_PIP_FLAGS"
+    - os: linux
+      env:
+         - PYTHON_VERSION=3.5
+         - MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh"
+         - EXTRA_PIP_FLAGS="$PRE_PIP_FLAGS"
 
 before_install:
 # https://github.com/travis-ci/travis-ci/issues/6522
@@ -39,7 +58,7 @@ before_install:
 - conda install --quiet python=$PYTHON_VERSION $CONDA_DEPS
 
 install:
-- pip install ".[analysis]"
+- pip install $EXTRA_PIP_FLAGS ".[analysis]"
 
 script:
 - py.test

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,17 +55,16 @@ before_install:
     - source venv/bin/activate
     - python --version # just to check
     - travis_retry pip install -U pip wheel  # needed at one point
-    - travis_retry pip install pytest pytest-xdist coveralls codecov
+    - travis_retry pip install pytest pytest-xdist pytest-cov codecov
 
 install:
 - pip install $EXTRA_PIP_FLAGS ".[analysis]"
 
 script:
-- py.test -n 2
+- py.test -n 2 -v --cov bids --cov-config .coveragerc --cov-report xml:cov.xml --doctest-modules bids
 
-after_success:
-- coveralls
-- bash <(curl -s https://codecov.io/bash)
+after_script:
+- codecov --file cov.xml --flags unittests
 
 cache: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,46 +16,30 @@ env:
 matrix:
   include:
     - os: osx
-      env:
-         - PYTHON_VERSION=2.7
-         - MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda2-latest-MacOSX-x86_64.sh"
+      python: 2.7
     - os: osx
-      env:
-         - PYTHON_VERSION=3.5
-         - MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh"
+      python: 3.5
     - os: linux
-      env:
-         - PYTHON_VERSION=2.7
-         - MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh"
+      python: 2.7
     - os: linux
-      env:
-         - PYTHON_VERSION=3.5
-         - MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh"
+      python: 3.5
     - os: linux
+      python: 2.7
       env:
-         - PYTHON_VERSION=2.7
-         - MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh"
          - EXTRA_PIP_FLAGS="$PRE_PIP_FLAGS"
     - os: linux
+      python: 3.5
       env:
-         - PYTHON_VERSION=3.5
-         - MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh"
          - EXTRA_PIP_FLAGS="$PRE_PIP_FLAGS"
 
 before_install:
-# https://github.com/travis-ci/travis-ci/issues/6522
-- if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then rvm get head || true; fi
-- export MINICONDA=$HOME/miniconda
-- export PATH="$MINICONDA/bin:$PATH"
-- hash -r
-- echo $MINICONDA_URL
-- wget $MINICONDA_URL -O miniconda.sh;
-- bash miniconda.sh -b -s -f -p $MINICONDA;
-- conda config --set always_yes yes
-- conda update conda
-- conda info -a
-- conda config --add channels conda-forge
-- conda install --quiet python=$PYTHON_VERSION $CONDA_DEPS
+    - travis_retry pip install --upgrade pip
+    - travis_retry pip install --upgrade virtualenv
+    - virtualenv --python=python venv
+    - source venv/bin/activate
+    - python --version # just to check
+    - travis_retry pip install -U pip wheel  # needed at one point
+    - travis_retry pip install coveralls codecov
 
 install:
 - pip install $EXTRA_PIP_FLAGS ".[analysis]"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,27 @@
+coverage:
+  range: "0...100"
+  status:
+    patch:
+      default:
+        target: 0
+        threshold: 100
+    project:
+      default:
+        target: 0
+        threshold: 100
+      patch:
+        target: 0
+        threshold: 100
+      unittests:
+        target: 0
+        threshold: 100
+        flags:
+          - "unittests"
+      smoketests:
+        target: 0
+        threshold: 100
+        flags:
+          - "smoketests"
+  ignore:          # files and folders that will be removed during processing
+    - "doc"
+    - "**/tests"


### PR DESCRIPTION
To avoid getting caught by API changes or have an opportunity to catch upstream bugs, we should test on pre-releases.

For speed, this replaces Miniconda with Travis's built-in Python environments, except for OSX, which still needs Miniconda.

Also, updated pytest to use parallelism and output coverage that Codecov can use.