### PR TITLE
Loop over get_event files, instead of merging

### DIFF
--- a/bids/variables/io.py
+++ b/bids/variables/io.py
@@ -158,7 +158,7 @@ def _load_time_variables(layout, dataset=None, columns=None, scan_length=None,
 
         # Process event files
         if events:
-            dfs = layout.get_events(img_f, derivatives=derivatives)
+            dfs = listify(layout.get_events(img_f, derivatives=derivatives))
             if dfs is not None:
                 for _data in dfs:
                     _data = pd.read_table(_data, sep='\t')

--- a/bids/variables/io.py
+++ b/bids/variables/io.py
@@ -158,47 +158,47 @@ def _load_time_variables(layout, dataset=None, columns=None, scan_length=None,
 
         # Process event files
         if events:
-            _data = layout.get_events(img_f, return_type='df',
-                                      derivatives=derivatives)
-            if _data is not None:
+            dfs = layout.get_events(img_f, derivatives=derivatives)
+            if dfs is not None:
+                for _data in dfs:
+                    _data = pd.read_table(_data, sep='\t')
+                    if 'amplitude' in _data.columns:
+                        if (_data['amplitude'].astype(int) == 1).all() and \
+                                'trial_type' in _data.columns:
+                            msg = ("Column 'amplitude' with constant value 1 is "
+                                   "unnecessary in event files; ignoring it.")
+                            _data = _data.drop('amplitude', axis=1)
+                        else:
+                            msg = ("Column name 'amplitude' is reserved; renaming "
+                                   "it to 'amplitude_'.")
+                            _data = _data.rename(
+                                columns={'amplitude': 'amplitude_'})
+                        warnings.warn(msg)
 
-                if 'amplitude' in _data.columns:
-                    if (_data['amplitude'].astype(int) == 1).all() and \
-                            'trial_type' in _data.columns:
-                        msg = ("Column 'amplitude' with constant value 1 is "
-                               "unnecessary in event files; ignoring it.")
-                        _data = _data.drop('amplitude', axis=1)
-                    else:
-                        msg = ("Column name 'amplitude' is reserved; renaming "
-                               "it to 'amplitude_'.")
-                        _data = _data.rename(
-                            columns={'amplitude': 'amplitude_'})
-                    warnings.warn(msg)
+                    _data = _data.replace('n/a', np.nan)  # Replace BIDS' n/a
+                    _data = _data.apply(pd.to_numeric, errors='ignore')
 
-                _data = _data.replace('n/a', np.nan)  # Replace BIDS' n/a
-                _data = _data.apply(pd.to_numeric, errors='ignore')
+                    _cols = columns or list(set(_data.columns.tolist()) -
+                                            {'onset', 'duration'})
 
-                _cols = columns or list(set(_data.columns.tolist()) -
-                                        {'onset', 'duration'})
+                    # Construct a DataFrame for each extra column
+                    for col in _cols:
+                        df = _data[['onset', 'duration']].copy()
+                        df['amplitude'] = _data[col].values
 
-                # Construct a DataFrame for each extra column
-                for col in _cols:
-                    df = _data[['onset', 'duration']].copy()
-                    df['amplitude'] = _data[col].values
+                        # Add in all of the run's entities as new columns for index
+                        for entity, value in entities.items():
+                            if entity in BASE_ENTITIES:
+                                df[entity] = value
 
-                    # Add in all of the run's entities as new columns for index
-                    for entity, value in entities.items():
-                        if entity in BASE_ENTITIES:
-                            df[entity] = value
+                        if drop_na:
+                            df = df.dropna(subset=['amplitude'])
 
-                    if drop_na:
-                        df = df.dropna(subset=['amplitude'])
+                        if df.empty:
+                            continue
 
-                    if df.empty:
-                        continue
-
-                    var = SparseRunVariable(col, df, run_info, 'events')
-                    run.add_variable(var)
+                        var = SparseRunVariable(col, df, run_info, 'events')
+                        run.add_variable(var)
 
         # Process confound files
         if confounds:


### PR DESCRIPTION
In `variables.io`, loop over `get_events` results, rather than merging, to avoid inserting unnecessary `n/a`s