### PR TITLE
fix: do not complain on import if missing optional deps

### DIFF
--- a/bids/__init__.py
+++ b/bids/__init__.py
@@ -3,8 +3,13 @@ from .due import due, Doi
 from . import config
 
 from .grabbids import BIDSLayout, BIDSValidator
-from .analysis import Analysis
-from .variables.io import load_variables
+
+try:
+    from .analysis import Analysis
+    from .variables.io import load_variables
+except ImportError as e:
+    pass
+
 
 
 __all__ = [

--- a/bids/analysis/tests/test_analysis.py
+++ b/bids/analysis/tests/test_analysis.py
@@ -1,10 +1,15 @@
 from os.path import join
 from bids.grabbids import BIDSLayout
-from bids.analysis import Analysis
-from bids.analysis.analysis import ContrastMatrixInfo, DesignMatrixInfo
+
 from bids.tests import get_test_data_path
 import pytest
 
+skip = pytest.importorskip("bids.analysis")
+
+from bids.analysis import Analysis
+from bids.analysis.analysis import ContrastMatrixInfo, DesignMatrixInfo
+# except ImportError:
+#     has_analysis = True
 
 @pytest.fixture
 def analysis():

--- a/bids/analysis/tests/test_automodel.py
+++ b/bids/analysis/tests/test_automodel.py
@@ -1,10 +1,12 @@
 from os.path import join
 from bids.grabbids import BIDSLayout
-from bids.analysis.auto_model import auto_model
-from bids.analysis import Analysis
 from bids.tests import get_test_data_path
 import pytest
 
+skip = pytest.importorskip("bids.analysis")
+
+from bids.analysis.auto_model import auto_model
+from bids.analysis import Analysis
 
 @pytest.fixture
 def model():

--- a/bids/analysis/tests/test_transformations.py
+++ b/bids/analysis/tests/test_transformations.py
@@ -1,12 +1,14 @@
 # from bids.analysis.variables import load_variables
-from bids.analysis import transformations as transform
-from bids.grabbids import BIDSLayout
 import pytest
 from os.path import join
 from bids.tests import get_test_data_path
+
+skip_analysis = pytest.importorskip("bids.analysis")
+
 import numpy as np
 import pandas as pd
-
+from bids.analysis import transformations as transform
+from bids.grabbids import BIDSLayout
 try:
     from pandas.core.groupby import _get_grouper
 except ImportError:

--- a/bids/grabbids/tests/test_grabbids.py
+++ b/bids/grabbids/tests/test_grabbids.py
@@ -6,6 +6,11 @@ from bids.grabbids import BIDSLayout
 from os.path import join, abspath, basename
 from bids.tests import get_test_data_path
 
+has_pandas = True
+try:
+    import pandas
+except ImportError:
+    has_pandas = False
 
 # Fixture uses in the rest of the tests
 @pytest.fixture(scope='module')
@@ -75,6 +80,7 @@ def test_get_metadata5(testlayout1):
     assert result['acquisition'] == 'fullbrain'
 
 
+@pytest.mark.skipif(not has_pandas, reason="Pandas not installed")
 def test_get_events(testlayout3):
     target = ('sub-01/func/sub-01_task-'
               'mixedgamblestask_run-01_bold.nii.gz')

--- a/bids/reports/tests/test_parsing.py
+++ b/bids/reports/tests/test_parsing.py
@@ -2,9 +2,11 @@ import json
 from os.path import abspath, join
 import pytest
 
-import nibabel as nib
+skip = pytest.importorskip("bids.reports.parsing")
 
 from bids.reports import parsing
+import nibabel as nib
+
 from bids.grabbids import BIDSLayout
 from bids.tests import get_test_data_path
 

--- a/bids/reports/tests/test_report.py
+++ b/bids/reports/tests/test_report.py
@@ -4,6 +4,8 @@ from os.path import join, abspath
 
 import pytest
 
+skip = pytest.importorskip('bids.reports.BIDSReport')
+
 from bids.grabbids import BIDSLayout
 from bids.reports import BIDSReport
 from bids.tests import get_test_data_path

--- a/bids/variables/tests/test_collections.py
+++ b/bids/variables/tests/test_collections.py
@@ -2,8 +2,10 @@ from bids.grabbids import BIDSLayout
 import pytest
 from os.path import join, dirname, abspath
 from bids.tests import get_test_data_path
-from bids.variables import DenseRunVariable, merge_collections
 
+skip = pytest.importorskip("bids.variables")
+
+from bids.variables import DenseRunVariable, merge_collections
 
 @pytest.fixture(scope="module")
 def run_coll():

--- a/bids/variables/tests/test_entities.py
+++ b/bids/variables/tests/test_entities.py
@@ -1,11 +1,12 @@
 from bids.grabbids import BIDSLayout
-from bids.variables.entities import RunNode, Node, NodeIndex
-from bids.variables import load_variables
-from bids.variables import BIDSRunVariableCollection
 import pytest
 from os.path import join
 from bids.tests import get_test_data_path
 
+skip = pytest.importorskip("bids.variables")
+
+from bids.variables.entities import RunNode, Node, NodeIndex
+from bids.variables import load_variables, BIDSRunVariableCollection
 
 @pytest.fixture(scope="module")
 def layout1():

--- a/bids/variables/tests/test_io.py
+++ b/bids/variables/tests/test_io.py
@@ -1,12 +1,14 @@
 from bids.grabbids import BIDSLayout
-from bids.variables import (SparseRunVariable, SimpleVariable,
-                            DenseRunVariable, load_variables)
-from bids.variables.entities import Node, RunNode, NodeIndex
 import pytest
 from os.path import join
 from bids.tests import get_test_data_path
 from bids.config import set_option
 
+skip = pytest.importorskip("bids.variables")
+
+from bids.variables import (SparseRunVariable, SimpleVariable,
+                            DenseRunVariable, load_variables)
+from bids.variables.entities import Node, RunNode, NodeIndex
 @pytest.fixture
 def layout1():
     path = join(get_test_data_path(), 'ds005')

--- a/bids/variables/tests/test_variables.py
+++ b/bids/variables/tests/test_variables.py
@@ -1,7 +1,10 @@
 from bids.grabbids import BIDSLayout
-import pytest
 from os.path import join
 from bids.tests import get_test_data_path
+import pytest
+
+skip = pytest.importorskip('bids.variables')
+
 from bids.variables import (merge_variables, DenseRunVariable, SimpleVariable,
                             load_variables)
 from bids.variables.entities import RunInfo


### PR DESCRIPTION
Fixes #204 

At first I was logging a warning when the import failed, but it seemed a little too noisy since some people will just be using the `BIDSLayout` functionality - however I can re-add if it's preferred