### PR TITLE
BF: return back "analysis" installation scheme if someone relied on it

### DIFF
--- a/bids/version.py
+++ b/bids/version.py
@@ -47,7 +47,11 @@ PLATFORMS = "OS Independent"
 # No data for now
 REQUIRES = ["grabbit>=0.2.2", "six", "num2words", "numpy", "scipy", "pandas",
             "nibabel", "patsy"]
-EXTRAS_REQUIRE = {}
+EXTRAS_REQUIRE = {
+   # Just to not break compatibility with externals requiring
+   # now deprecated installation schemes
+   'analysis': []
+}
 TESTS_REQUIRE = ["pytest>=3.3.0"]
 
 


### PR DESCRIPTION
It is just an empty list since all of them moved into the main
set of dependencies, but this would allow external tools which
demanded it before still function without fixups, see e.g
https://github.com/nipy/heudiconv/issues/235#issuecomment-408193202