### PR TITLE
Add binder link for tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## PyBIDS
 [![Build Status (Linux and OS X)](https://travis-ci.org/INCF/pybids.svg?branch=master)](https://travis-ci.org/INCF/pybids)
 [![Build Status (Windows)](https://ci.appveyor.com/api/projects/status/5aa4c6e3m15ew4v7?svg=true)](https://ci.appveyor.com/project/chrisfilo/pybids-ilb80)
-[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/KirstieJane/pybids/master?filepath=https%3A%2F%2Fgithub.com%2FKirstieJane%2Fpybids%2Fblob%2Fmaster%2Fexamples%2Fpybids%2520tutorial.ipynb)
+[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/INCF/pybids/master)
 
 PyBIDS is a Python library to centralize interactions with datasets conforming
 BIDS (Brain Imaging Data Structure) format.  For more information about BIDS
@@ -9,4 +9,4 @@ visit http://bids.neuroimaging.io.
 
 Get started by checking out [the documentation!](https://incf.github.io/pybids)
 
-Or you can start at [our tutorial!](examples/pybids%20tutorial.ipynb). You can even run it interactively without installing anything via [binder](https://mybinder.org/v2/gh/KirstieJane/pybids/master?filepath=https%3A%2F%2Fgithub.com%2FKirstieJane%2Fpybids%2Fblob%2Fmaster%2Fexamples%2Fpybids%2520tutorial.ipynb)
+Or you can start at [our tutorial!](examples/pybids%20tutorial.ipynb). You can run it interactively without installing anything via [binder](https://mybinder.org/v2/gh/INCF/pybids/master). Click on the link and then navigate to `examples/pybids_tutorial.ipynb` to explore.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## PyBIDS
 [![Build Status (Linux and OS X)](https://travis-ci.org/INCF/pybids.svg?branch=master)](https://travis-ci.org/INCF/pybids)
 [![Build Status (Windows)](https://ci.appveyor.com/api/projects/status/5aa4c6e3m15ew4v7?svg=true)](https://ci.appveyor.com/project/chrisfilo/pybids-ilb80)
-
+[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/KirstieJane/pybids/master?filepath=https%3A%2F%2Fgithub.com%2FKirstieJane%2Fpybids%2Fblob%2Fmaster%2Fexamples%2Fpybids%2520tutorial.ipynb)
 
 PyBIDS is a Python library to centralize interactions with datasets conforming
 BIDS (Brain Imaging Data Structure) format.  For more information about BIDS
@@ -9,4 +9,4 @@ visit http://bids.neuroimaging.io.
 
 Get started by checking out [the documentation!](https://incf.github.io/pybids)
 
-[Check out our tutorial!](examples/pybids%20tutorial.ipynb)
+Or you can start at [our tutorial!](examples/pybids%20tutorial.ipynb). You can even run it interactively without installing anything via [binder](https://mybinder.org/v2/gh/KirstieJane/pybids/master?filepath=https%3A%2F%2Fgithub.com%2FKirstieJane%2Fpybids%2Fblob%2Fmaster%2Fexamples%2Fpybids%2520tutorial.ipynb)

--- a/bids/version.py
+++ b/bids/version.py
@@ -46,7 +46,7 @@ AUTHOR_EMAIL = "bids-discussion@googlegroups.com"
 PLATFORMS = "OS Independent"
 # No data for now
 REQUIRES = ["grabbit>=0.2.2", "six", "num2words", "numpy", "scipy", "pandas",
-            "nibabel", "patsy"]
+            "nibabel", "patsy", "pytest"]
 EXTRAS_REQUIRE = {
    # Just to not break compatibility with externals requiring
    # now deprecated installation schemes

--- a/bids/version.py
+++ b/bids/version.py
@@ -46,7 +46,7 @@ AUTHOR_EMAIL = "bids-discussion@googlegroups.com"
 PLATFORMS = "OS Independent"
 # No data for now
 REQUIRES = ["grabbit>=0.2.2", "six", "num2words", "numpy", "scipy", "pandas",
-            "nibabel", "patsy", "pytest", "duecredit"]
+            "nibabel", "patsy"]
 EXTRAS_REQUIRE = {
    # Just to not break compatibility with externals requiring
    # now deprecated installation schemes

--- a/bids/version.py
+++ b/bids/version.py
@@ -46,7 +46,7 @@ AUTHOR_EMAIL = "bids-discussion@googlegroups.com"
 PLATFORMS = "OS Independent"
 # No data for now
 REQUIRES = ["grabbit>=0.2.2", "six", "num2words", "numpy", "scipy", "pandas",
-            "nibabel", "patsy", "pytest"]
+            "nibabel", "patsy", "pytest", "duecredit"]
 EXTRAS_REQUIRE = {
    # Just to not break compatibility with externals requiring
    # now deprecated installation schemes


### PR DESCRIPTION
I've added a link in the README to binder so that people can run the tutorial without having to download anything.

The change that needs more careful review is that I've added `pytest` and `duecredit` to [`bids/version.py`](https://github.com/INCF/pybids/pull/225/files#diff-bf0ebf03d2ee99d8b4c3ca51e95c3495).

Pytest is necessary, duecredit just shows a warning when it can't be found.

Happy to iterate if needed!