### PR TITLE
don't need to import tests in __init__.py

### DIFF
--- a/bids/tests/__init__.py
+++ b/bids/tests/__init__.py
@@ -1,10 +1,6 @@
 from .utils import get_test_data_path
-from .test_config import (
-    test_load_from_standard_paths, test_set_option, test_get_option)
+
 
 __all__ = [
     'get_test_data_path',
-    'test_load_from_standard_paths',
-    'test_set_option',
-    'test_get_option'
 ]


### PR DESCRIPTION
Closes #220 by preventing tests from being imported when accessing `get_test_data_path`.