### PR TITLE
FIX: Run should be returned as an int

### DIFF
--- a/bids/layout/config/bids.json
+++ b/bids/layout/config/bids.json
@@ -39,7 +39,8 @@
         },
         {
             "name": "run",
-            "pattern": "[_/\\\\]run-0*(\\d+)"
+            "pattern": "[_/\\\\]run-0*(\\d+)",
+            "dtype": "int"
         },
         {
             "name": "proc",


### PR DESCRIPTION
`parse_file_entities` is not returning runs as ints. Comparing to the test.json in grabbit, this seems to be the problem.

Don't have time to test right now, but @adelavega, you can check if this resolves issues in zPY.