### PR TITLE
Make sure codespell skips .git when run locally

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -80,5 +80,5 @@ tag_prefix =
 parentdir_prefix =
 
 [codespell]
-skip = external,versioneer.py,_version.py
+skip = ./.git,external,versioneer.py,_version.py
 ignore-words = .github/codespell_ignore_words.txt


### PR DESCRIPTION
While there's no `.git` directory to skip when codespell is run by CI, modify the setup to skip `.git` when running codespell locally.