### PR TITLE
chore: Add Python 3.14 tests

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -52,7 +52,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest', 'macos-latest']
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         dependencies: ['full']
         source: ['repo']
         include:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest', 'macos-latest']
-        python-version: ['3.12', '3.13']
+        python-version: ['3.12', '3.13', '3.14']
       fail-fast: false
 
     permissions:

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ requires =
   tox>=4
   tox-uv
 envlist =
-  py31{0,1,2,3}-{full,pre}
+  py31{0,1,2,3,4}-{full,pre}
   py310-min
 skip_missing_interpreters = true
 
@@ -14,6 +14,7 @@ python =
   3.11: py311
   3.12: py312
   3.13: py313
+  3.14: py314
 
 [gh-actions:env]
 DEPENDS =


### PR DESCRIPTION
Not all of our dependencies can be installed on 3.14 just yet, so leaving this as a draft.