### PR TITLE
Fix metadata inheritance for multi-echo data (fixes #1044)

### DIFF
--- a/src/bids/layout/index.py
+++ b/src/bids/layout/index.py
@@ -400,23 +400,33 @@ class BIDSLayoutIndexer:
             while True:
                 # Get JSON payloads
                 json_data = file_data.get(json_key, {}).get(dirname, [])
+                dir_payloads = []
                 for js_ents, js_md, js_path in json_data:
                     js_keys = set(js_ents.keys())
                     if js_keys - file_ent_keys:
                         continue
                     matches = [js_ents[name] == file_ents[name] for name in js_keys]
                     if all(matches):
-                        payloads.append((js_md, js_path))
+                        dir_payloads.append((len(js_keys), js_md, js_path))
+                
+                dir_payloads.sort(key=lambda x: x[0], reverse=True)
+                for _, js_md, js_path in dir_payloads:
+                    payloads.append((js_md, js_path))
 
                 # Get all files this file inherits from
                 candidates = file_data.get(ext_key, {}).get(dirname, [])
+                dir_ancestors = []
                 for ents, _, path in candidates:
                     keys = set(ents.keys())
                     if keys - file_ent_keys:
                         continue
                     matches = [ents[name] == file_ents[name] for name in keys]
                     if all(matches):
-                        ancestors.append(path)
+                        dir_ancestors.append((len(keys), path))
+                
+                dir_ancestors.sort(key=lambda x: x[0], reverse=True)
+                for _, path in dir_ancestors:
+                    ancestors.append(path)
 
                 parent = dirname.parent
 


### PR DESCRIPTION

### Description
Fixes #1044 

This PR addresses an issue where inherited metadata could incorrectly override immediate metadata for multi-echo data (or other sidecars at the same directory level) when they share the same base entities.

#### The Issue
According to BIDS inheritance principles, when multiple JSON sidecars apply to a given data file, the sidecar that shares the *most* matching entities should take precedence (e.g. `_echo-2_bold.json` should override `_bold.json`). 
Previously, `BIDSLayout` was appending matching JSON sidecars at the same directory level in an arbitrary order before generating the reverse inheritance stack. This resulted in less specific generic sidecars sometimes erroneously overriding the more specific sidecars.

#### The Fix
Added a deterministic sort to `src/bids/layout/index.py` for all JSON payloads and ancestors found at any given directory level. By sorting the payloads by the number of matching entities in descending order, we guarantee that the more generic files are processed first and the more specific files (with more entities) are processed last during the reverse stack update. 

This ensures that the sidecar with the most entities correctly takes precedence.

***