### PR TITLE
ENH: Allow dictionary input for BIDSLayout derivatives parameter to s…

### DIFF
--- a/src/bids/layout/layout.py
+++ b/src/bids/layout/layout.py
@@ -596,16 +596,27 @@ class BIDSLayout:
         return parse_file_entities(filename, entities, config, include_unmatched)
 
     def _get_derivative_dirs(self, paths):
-        for path in paths:
-            p = Path(path).absolute()
-            base = p.name
-            if Path.exists(p / 'dataset_description.json'):
-                yield (base, p)
-            else:
-                yield from (
-                    (f'{base}/{dd.parent.name}', dd.parent)
-                    for dd in p.glob('*/dataset_description.json')
-                )
+        if isinstance(paths, dict):
+            for name, path in paths.items():
+                p = Path(path).absolute()
+                if Path.exists(p / 'dataset_description.json'):
+                    yield (name, p)
+                else:
+                    yield from (
+                        (f'{name}/{dd.parent.name}', dd.parent)
+                        for dd in p.glob('*/dataset_description.json')
+                    )
+        else:
+            for path in paths:
+                p = Path(path).absolute()
+                base = p.name
+                if Path.exists(p / 'dataset_description.json'):
+                    yield (base, p)
+                else:
+                    yield from (
+                        (f'{base}/{dd.parent.name}', dd.parent)
+                        for dd in p.glob('*/dataset_description.json')
+                    )
 
     def add_derivatives(self, path, parent_database_path=None, **kwargs):
         """Add BIDS-Derivatives datasets to tracking.
@@ -632,7 +643,11 @@ class BIDSLayout:
         specification for details.
 
         """
-        paths = listify(path)
+        is_custom_dict = isinstance(path, dict)
+        if is_custom_dict:
+            paths = path
+        else:
+            paths = listify(path)
         if parent_database_path:
             parent_database_path = Path(parent_database_path)
         deriv_paths = list(self._get_derivative_dirs(paths))
@@ -661,7 +676,10 @@ class BIDSLayout:
                     f'Pipeline name {name} ({path!s}) has already been added to this '
                     'BIDSLayout. Every added pipeline must have a unique name!'
                 )
-            self.derivatives[name] = BIDSLayout(path, is_derivative=True, **kwargs)
+            deriv = BIDSLayout(path, is_derivative=True, **kwargs)
+            if is_custom_dict:
+                deriv.source_pipeline = name
+            self.derivatives[name] = deriv
 
     def to_df(self, metadata=False, **filters):
         """Return information for BIDSFiles tracked in Layout as pd.DataFrame.

--- a/src/bids/layout/models.py
+++ b/src/bids/layout/models.py
@@ -82,9 +82,15 @@ class LayoutInfo(Base):
 
         # Get abspaths
         if kwargs.get('derivatives') not in (None, True, False):
-            kwargs['derivatives'] = [
-                str(UPath(der).absolute()) for der in listify(kwargs['derivatives'])
-            ]
+            if isinstance(kwargs['derivatives'], dict):
+                kwargs['derivatives'] = {
+                    name: str(UPath(der).absolute()) 
+                    for name, der in kwargs['derivatives'].items()
+                }
+            else:
+                kwargs['derivatives'] = [
+                    str(UPath(der).absolute()) for der in listify(kwargs['derivatives'])
+                ]
 
         if kwargs.pop('absolute_paths', True) is not True:
             warnings.warn(

--- a/src/bids/layout/tests/test_layout.py
+++ b/src/bids/layout/tests/test_layout.py
@@ -1355,3 +1355,13 @@ def test_bids_sort(layout_7t_trt):
 
     assert list(first_file_ents_unsorted.keys()) != sorted_keys
     assert list(bids_sort(first_file_ents_unsorted).keys()) == sorted_keys
+
+def test_derivatives_dictionary_input(tests_dir):
+    data_dir = os.path.join(tests_dir, 'data', 'ds005')
+    deriv_dir = os.path.join(tests_dir, 'data', 'ds005_derivs', 'dummy-vx.x.x')
+    layout = BIDSLayout(data_dir, derivatives={'my_custom_pipeline': deriv_dir})
+    
+    assert 'my_custom_pipeline' in layout.derivatives
+    assert layout.derivatives['my_custom_pipeline'].source_pipeline == 'my_custom_pipeline'
+    assert len(layout.get(scope='my_custom_pipeline', extension='.nii.gz')) == 3
+    assert len(layout.get(scope='dummy', extension='.nii.gz')) == 0


### PR DESCRIPTION
**Fixes #1155**

### Description
This PR introduces the ability to pass a dictionary to the `derivatives` parameter in `BIDSLayout` (or `layout.add_derivatives()`) to map custom names to derivative pipelines. 

Previously, PyBIDS strictly extracted the pipeline name from the derivative's base directory name or `dataset_description.json`. This was inflexible and forced users to query derivatives using potentially messy directory names. 

Now, users can pass a dictionary mapping custom names to derivative paths (e.g., `layout = BIDSLayout(data_dir, derivatives={'my_clean_pipeline': '/path/to/ugly_pipeline_name_v1.0.0'})`). The specified dictionary key will explicitly override the derivative's `source_pipeline` property, allowing intuitive and clean queries via `layout.get(scope='my_clean_pipeline')`. 

### Changes Made
- Modified `_get_derivative_dirs` in `src/bids/layout/layout.py` to support `dict` paths, yielding the custom key instead of parsing the directory name.
- Modified `add_derivatives` in `src/bids/layout/layout.py` to prevent `listify` from destroying dictionary structures, and overrode the spawned `BIDSLayout`'s `source_pipeline` property with the user's custom dictionary key.
- Updated `_sanitize_init_args` in `src/bids/layout/models.py` to properly serialize and sanitize dictionary initialization arguments for the layout database.
