### PR TITLE
[FIX] Make BIDSLayout.save idempotent when re-saving to the same path

### DIFF
--- a/src/bids/layout/db.py
+++ b/src/bids/layout/db.py
@@ -131,14 +131,26 @@ class ConnectionManager:  # noqa: D101
 
         """
         database_file = get_database_file(database_path)
-        new_db = sqlite3.connect(str(database_file))
         old_db = self.engine.connect().connection
+
+        # Dump into a fresh temporary file and atomically move it into place.
+        # ``iterdump`` emits plain ``CREATE TABLE`` statements that raise
+        # "table ... already exists" when replayed into a database that already
+        # holds the schema, so the destination must start empty. Building a new
+        # file first (rather than clearing ``database_file`` in place) also keeps
+        # re-saving safe when the destination is the current database file, i.e.
+        # ``old_db`` and ``database_file`` alias the same path. See gh-1079.
+        temp_file = database_file.with_name(f'.{database_file.name}.tmp')
+        temp_file.unlink(missing_ok=True)
+        new_db = sqlite3.connect(str(temp_file))
 
         with new_db:
             for line in old_db.iterdump():
                 if line not in ('BEGIN;', 'COMMIT;'):
                     new_db.execute(line)
             new_db.commit()
+        new_db.close()
+        temp_file.replace(database_file)
 
         if replace_connection:
             return ConnectionManager(database_path, init_args=self.layout_info)

--- a/src/bids/layout/tests/test_db.py
+++ b/src/bids/layout/tests/test_db.py
@@ -1,6 +1,7 @@
 """Test functionality in the db module--mostly related to connection
 management."""
 
+from bids.layout import BIDSLayout
 from bids.layout.db import get_database_file
 
 
@@ -11,3 +12,20 @@ def test_get_database_file(tmp_path):
     db_file = get_database_file(new_path)
     assert db_file == new_path / 'layout_index.sqlite'
     assert new_path.exists()
+
+
+def test_save_database_twice_same_path(tests_dir, tmp_path):
+    """Saving to the same path twice must be idempotent (gh-1079)."""
+    layout = BIDSLayout(tests_dir / 'data' / 'ds005')
+    db_path = str(tmp_path / 'db')
+
+    layout.save(db_path)
+    # This used to raise sqlite3.OperationalError: table associations
+    # already exists, because the destination already held the schema.
+    layout.save(db_path)
+
+    # The re-saved database must still be complete and reloadable.
+    reloaded = BIDSLayout(tests_dir / 'data' / 'ds005', database_path=db_path)
+    assert sorted(layout.get(return_type='file')) == sorted(
+        reloaded.get(return_type='file')
+    )


### PR DESCRIPTION
Closes #1079.

## Why

Calling `layout.save(path)` a second time against the same path raises:

```
sqlite3.OperationalError: table associations already exists
```

This bites users who re-run a script: the first run creates
`<path>/layout_index.sqlite`, and a second `save()` to the same path fails.
@effigies reproduced it in the issue thread and noted it wasn't obvious to fix.

## Root cause

`ConnectionManager.save_database` (`src/bids/layout/db.py`) snapshots the index by
replaying `sqlite3.Connection.iterdump()` into `sqlite3.connect(database_file)`.
`iterdump()` emits plain `CREATE TABLE ...` (no `IF NOT EXISTS`, no `DROP`), so
replaying into a `database_file` that **already holds the schema** (from a prior
save) collides on the first table — `associations`.

The reason a naive fix (deleting/truncating the destination first) does **not**
work is subtle, and is likely why this looked unfixable: with the default
`replace_connection=True`, the first `save()` re-points the layout's connection at
the saved file. A subsequent `save()` to the same path therefore has **`old_db`
(source) and `database_file` (destination) aliasing the same file** — clearing the
destination in place would destroy the source before `iterdump()` reads it
(confirmed: it produces an empty / `no such table: layout_info` database).

## What

Dump into a fresh temporary file in the same directory, then atomically move it
into place:

```python
temp_file = database_file.with_name(f'.{database_file.name}.tmp')
temp_file.unlink(missing_ok=True)
new_db = sqlite3.connect(str(temp_file))
with new_db:
    for line in old_db.iterdump():
        if line not in ('BEGIN;', 'COMMIT;'):
            new_db.execute(line)
    new_db.commit()
new_db.close()
temp_file.replace(database_file)
```

- The destination always starts empty, so `CREATE TABLE` never collides.
- The destination is only touched at the final `replace()`, so re-saving stays
  correct even when source and destination are the same file.
- Streaming via `iterdump()` is preserved; `replace()` is a same-directory atomic
  rename.

## Tests

Added `test_save_database_twice_same_path` to `src/bids/layout/tests/test_db.py`:
saves a layout to the same path twice (default `replace_connection=True`,
exercising the same-file path) and asserts the re-saved database is complete and
reloadable.

- **Before:** fails with `OperationalError: table associations already exists`.
- **After:** passes.
- `pytest src/bids/layout/tests/` → 193 passed, 71 skipped (network/submodule
  gated), 1 xfailed, 0 failed.

## Caveats (flagging honestly)

- **Windows, same-process same-file re-save:** on the second same-file save,
  `old_db` still holds the destination open when `replace()` runs, which can raise
  `PermissionError` on Windows. This is **not a regression** (the current code
  already raises on the second save everywhere), and pybids CI is Linux/macOS only;
  first saves and cross-path saves are unaffected. Happy to guard it (close
  `old_db` before `replace()`) if you'd like it fully Windows-safe.
- **Concurrent saves to the same path** remain unsupported (unchanged from before).
- Happy to fold in polish if preferred: a process-unique temp name
  (`tempfile.mkstemp(dir=...)`), a `try/finally` to clean the temp on error, and/or
  a stronger completeness assertion in the test.

No `CHANGELOG.rst` edit — this project compiles the changelog from PR titles via
release-drafter.
