### PR TITLE
Fix zero-padded integer metadata conflicts

### DIFF
--- a/src/bids/layout/index.py
+++ b/src/bids/layout/index.py
@@ -507,7 +507,15 @@ class BIDSLayoutIndexer:
                 # Skip pairs that were already found in the filenames
                 if tag_string in all_tags:
                     file_val = all_tags[tag_string]
-                    if str(md_val) != file_val:
+                    entity = all_entities.get(md_key)
+                    values_match = str(md_val) == file_val
+                    if (
+                        entity is not None
+                        and entity._dtype == 'int'
+                        and not isinstance(md_val, bool)
+                    ):
+                        values_match = entity._astype(file_val) == md_val
+                    if not values_match:
                         msg = (
                             "Conflicting values found for entity '{}' in "
                             "filename {} (value='{}') versus its JSON sidecar "

--- a/src/bids/layout/tests/test_layout.py
+++ b/src/bids/layout/tests/test_layout.py
@@ -13,6 +13,7 @@ import pytest
 
 from bids.exceptions import (
     BIDSChildDatasetError,
+    BIDSConflictingValuesError,
     BIDSDerivativesValidationError,
     BIDSValidationError,
     NoMatchError,
@@ -963,6 +964,37 @@ def test_indexing_tag_conflict(tests_dir):
         layout = BIDSLayout(data_dir)
     assert str(exc.value).startswith('Conflicting values found')
     assert 'run' in str(exc.value)
+
+
+@pytest.mark.parametrize('metadata_run', [1, 1.0])
+def test_indexing_zero_padded_entity_matches_numeric_metadata(tmp_path, metadata_run):
+    (tmp_path / 'dataset_description.json').write_text(
+        json.dumps({'Name': 'test', 'BIDSVersion': '1.10.0'})
+    )
+    func_dir = tmp_path / 'sub-01' / 'func'
+    func_dir.mkdir(parents=True)
+    bold_file = func_dir / 'sub-01_task-rest_run-01_bold.nii.gz'
+    bold_file.touch()
+    bold_file.with_suffix('').with_suffix('.json').write_text(json.dumps({'run': metadata_run}))
+
+    layout = BIDSLayout(tmp_path)
+
+    assert layout.get(run=1, suffix='bold', extension='.nii.gz')
+
+
+@pytest.mark.parametrize('metadata_run', [2, 1.5, True, '1'])
+def test_indexing_zero_padded_entity_rejects_conflicting_metadata(tmp_path, metadata_run):
+    (tmp_path / 'dataset_description.json').write_text(
+        json.dumps({'Name': 'test', 'BIDSVersion': '1.10.0'})
+    )
+    func_dir = tmp_path / 'sub-01' / 'func'
+    func_dir.mkdir(parents=True)
+    bold_file = func_dir / 'sub-01_task-rest_run-01_bold.nii.gz'
+    bold_file.touch()
+    bold_file.with_suffix('').with_suffix('.json').write_text(json.dumps({'run': metadata_run}))
+
+    with pytest.raises(BIDSConflictingValuesError, match="entity 'run'"):
+        BIDSLayout(tmp_path)
 
 
 def test_get_with_wrong_dtypes(layout_7t_trt):


### PR DESCRIPTION
## Summary

- compare duplicate filename and sidecar values using the configured integer entity conversion
- treat zero-padded filename entities such as `run-01` as equivalent to numeric metadata values such as `1`
- preserve conflict detection for booleans, strings, non-integral numbers, and different numeric values

## Root cause

Metadata indexing compared the string representation of both values, so the filename value `"01"` and the JSON number `1` were treated as different even though the `run` entity is configured as an integer.

## Validation

- `python -m pytest src/bids/layout/tests/test_layout.py -q` — 109 passed
- `ruff format --check src/bids/layout/index.py src/bids/layout/tests/test_layout.py`
- `git diff --check`

Fixes #1255
