### PR TITLE
Fix:  get_collection("session").to_df() to include all in scans.tsv

### DIFF
--- a/src/bids/variables/collections.py
+++ b/src/bids/variables/collections.py
@@ -199,13 +199,13 @@ class BIDSVariableCollection:
             with _pandas_3_0():
                 df = df.reset_index(drop=True).fillna(fillna).infer_objects()
         else:
-            # Rows in wide format can only be defined by combinations of level entities
-            # plus (for run-level variables) onset and duration.
-            valid_vars = {'run', 'session', 'subject', 'dataset', 'onset', 'duration'}
-            idx_cols = list(valid_vars & all_cols)
+            # pivot everything but the condtion<->amplitude long format pairing
+            idx_cols = df.columns.difference(['condition', 'amplitude']).to_list()
 
             with _pandas_3_0():
-                df['amplitude'] = df['amplitude'].fillna('n/a')
+                # pivot_table(...,dropna=False) will create new rows
+                for col in df.columns:
+                    df[col] = df[col].fillna('n/a')
             wide_df = df.pivot_table(
                 index=idx_cols, columns='condition', values='amplitude', aggfunc='first'
             )

--- a/src/bids/variables/collections.py
+++ b/src/bids/variables/collections.py
@@ -187,7 +187,8 @@ class BIDSVariableCollection:
         # timing flags through to the individual variables and then do
         # concat/reshaping operations. So instead, we set them all to True
         # temporarily, do what we need to, then drop them later if needed.
-        dfs = [v.to_df(True, True, timing=True) for v in variables]
+        dfs = [v.to_df(condition=True, entities=True, timing=True)
+               for v in variables]
 
         # Always concatenate along row axis (for format='wide', we'll pivot).
         df = pd.concat(dfs, axis=0, sort=True)
@@ -199,12 +200,18 @@ class BIDSVariableCollection:
             with _pandas_3_0():
                 df = df.reset_index(drop=True).fillna(fillna).infer_objects()
         else:
-            # pivot everything but the condtion<->amplitude long format pairing
+            #: columns to replace None with n/a so they are not dropped
+            fill_cols = df.columns
+            #: columns to keep in long->wide pivot
             idx_cols = df.columns.difference(['condition', 'amplitude']).to_list()
+            # pivot everything but the condtion<->amplitude long format pairing
+            # could consider
+            #   testing self.level == 'run' for expliclty enumerating level entities
+            #   or using self.variables.keys() and self.entities.keys()
 
             with _pandas_3_0():
                 # pivot_table(...,dropna=False) will create new rows
-                for col in df.columns:
+                for col in fill_cols:
                     df[col] = df[col].fillna('n/a')
             wide_df = df.pivot_table(
                 index=idx_cols, columns='condition', values='amplitude', aggfunc='first'

--- a/src/bids/variables/tests/test_collections.py
+++ b/src/bids/variables/tests/test_collections.py
@@ -360,3 +360,18 @@ def test_n_variables(run_coll_derivs):
     # Test that collections have not incorrectly merged multiple subjects
     for c in run_coll_derivs:
         assert 'subject' in c.entities
+
+
+def test_collect_events():
+    "Confirm all rows of events.tsv are parsed into dataframe."
+    path = join(get_test_data_path(), "synthetic")
+    layout = BIDSLayout(path)
+    ses = layout.get_collections("session", subject="01", session="01", merge=True)
+    first_var = list(ses.variables.values())[0].values.to_list()
+    # collection built will all variables for scans. T1w, 2x nback, rest
+    assert len(first_var) == 4
+    # collection converted to dataframe
+    ses_df = ses.to_df()
+    # TODO: fix bids/variables/collections.py(207)to_df()'s df.pivot_table
+    # issue #604
+    assert ses_df.shape[0] == 4

--- a/src/bids/variables/tests/test_collections.py
+++ b/src/bids/variables/tests/test_collections.py
@@ -1,6 +1,7 @@
 from os.path import join
 
 import numpy as np
+import pandas as pd
 import pytest
 
 from bids.layout import BIDSLayout
@@ -48,6 +49,11 @@ def run_coll_derivs():
         'run', types=['events', 'regressors'], merge=False, scan_length=480, subject=['01', '02']
     )
 
+@pytest.fixture(scope='module')
+def layout_syn():
+    path = join(get_test_data_path(), 'synthetic')
+    layout = BIDSLayout(path)
+    return layout
 
 def test_run_variable_collection_init(run_coll):
     assert isinstance(run_coll.variables, dict)
@@ -308,6 +314,16 @@ def test_run_variable_collection_to_df_mixed_vars(run_coll):
     assert not {'RT', 'respcat'} - set(df.columns)
 
 
+def test_variable_collection_to_df_syn(layout_syn):
+    """Test variable.to_df, issue #1275.
+    Also see src/bids/variables/tests/test_variables.py
+    """
+    runc = layout_syn.get_collections("run", subject="01", session="01")
+    resp_var = runc[0].variables['respiratory']
+    sub_list = pd.unique(resp_var.to_df(True, True, True).subject)
+    assert sub_list == ['01']
+
+
 def test_merge_collections(run_coll, run_coll_list):
     df1 = run_coll.to_df().sort_values(['subject', 'run', 'onset'])
     rcl = [c.clone() for c in run_coll_list]
@@ -362,13 +378,13 @@ def test_n_variables(run_coll_derivs):
         assert 'subject' in c.entities
 
 
-def test_collect_events():
-    "Confirm all rows of events.tsv are parsed into dataframe."
+def test_collect_session():
+    "Confirm all rows of scans.tsv are parsed into dataframe."
     path = join(get_test_data_path(), "synthetic")
     layout = BIDSLayout(path)
     ses = layout.get_collections("session", subject="01", session="01", merge=True)
     first_var = list(ses.variables.values())[0].values.to_list()
-    # collection built will all variables for scans. T1w, 2x nback, rest
+    # collection built with all variables for scans. T1w, 2x nback, rest
     assert len(first_var) == 4
     # collection converted to dataframe
     ses_df = ses.to_df()
@@ -378,3 +394,28 @@ def test_collect_events():
     # find  tests/data/synthetic/ -iname '*scans.tsv' -exec sed 1d {} \; |wc -l # 40
     ses_full_df = layout.get_collections("session", merge=True).to_df()
     assert ses_full_df.shape[0] == 40
+
+
+def test_collect_run(layout_syn):
+    "Confirm all rows of events.tsv are parsed into dataframe."
+    runc = layout_syn.get_collections("run", subject="01", session="01", merge=True)
+    first_var = list(runc.variables.values())[0].values.to_list()
+    # find  tests/data/synthetic/ -iname '*events.tsv'|xargs wc -l
+    #  43 tests/data/synthetic/task-nback_events.tsv
+    assert len(first_var) == 42*2  # two nback runs
+
+    # find tests/data/synthetic/  -iname '*sub-01*phys*' | while read f; do echo "$(zcat $f|wc -l) ${f/*synthetic/}"; done; wc -l tests/data/synthetic/task-*events.tsv
+    #  1600 /sub-01/ses-01/func/sub-01_ses-01_task-nback_run-01_physio.tsv.gz
+    #  1600 /sub-01/ses-01/func/sub-01_ses-01_task-nback_run-02_physio.tsv.gz
+    #  1600 /sub-01/ses-01/func/sub-01_ses-01_task-rest_physio.tsv.gz
+    #  1600 /sub-01/ses-02/func/sub-01_ses-02_task-nback_run-01_physio.tsv.gz
+    #  1600 /sub-01/ses-02/func/sub-01_ses-02_task-nback_run-02_physio.tsv.gz
+    #  1600 /sub-01/ses-02/func/sub-01_ses-02_task-rest_physio.tsv.gz
+
+    # issue #1275
+    resp = runc.variables['respiratory'].to_df(True, True)
+    assert resp.subject.unique().tolist() == ['01']
+
+    # collection converted to dataframe
+    run_df = runc.to_df()
+    assert run_df.shape[0] == 1600*3  # 2x nback + rest

--- a/src/bids/variables/tests/test_collections.py
+++ b/src/bids/variables/tests/test_collections.py
@@ -372,6 +372,9 @@ def test_collect_events():
     assert len(first_var) == 4
     # collection converted to dataframe
     ses_df = ses.to_df()
-    # TODO: fix bids/variables/collections.py(207)to_df()'s df.pivot_table
-    # issue #604
     assert ses_df.shape[0] == 4
+
+    # read in all events across study
+    # find  tests/data/synthetic/ -iname '*scans.tsv' -exec sed 1d {} \; |wc -l # 40
+    ses_full_df = layout.get_collections("session", merge=True).to_df()
+    assert ses_full_df.shape[0] == 40

--- a/src/bids/variables/tests/test_variables.py
+++ b/src/bids/variables/tests/test_variables.py
@@ -40,6 +40,13 @@ def layout2():
     return layout
 
 
+@pytest.fixture(scope='module')
+def layout_syn():
+    path = join(get_test_data_path(), 'synthetic')
+    layout = BIDSLayout(path)
+    return layout
+
+
 def test_dense_event_variable_init():
     dev = generate_DEV()
     assert dev.sampling_rate == 20
@@ -186,6 +193,29 @@ def test_sparse_run_variable_to_df(layout1):
 
 def test_dense_run_variable_to_df(layout2):
     pass
+
+
+def test_syn_run_variable_to_df(layout_syn):
+    dataset = load_variables(layout_syn, levels=['session', 'run'])
+    runs = dataset.get_nodes('run')
+    rows_per_run = [x.variables['respiratory'].to_df(True, True).shape[0]
+                    for x in runs]
+    subjs = [x.variables['cardiac'].index.subject.unique().tolist()
+             for x in runs]
+    # 5 subjs * 2 sessions * 3 runs
+    assert len(rows_per_run) == 30
+    # all runs have physio with 1600 samples
+    assert rows_per_run == [1600] * len(rows_per_run)
+    assert np.unique(subjs).tolist() == ['01', '02', '03', '04', '05']
+
+
+def test_syn_run_variable_to_df_merge(layout_syn):
+    "Check issue #1275. count reps and fill merge dataframe."
+    dataset = load_variables(layout_syn, levels=['session', 'run'])
+    col = dataset.get_collections('run', 'cardiac', merge=True)
+    subjs = col.variables['cardiac'].index.subject.unique().tolist()
+    assert np.unique(subjs).tolist() == ['01', '02', '03', '04', '05']
+
 
 
 def test_filter_simple_variable(layout2):

--- a/src/bids/variables/variables.py
+++ b/src/bids/variables/variables.py
@@ -229,6 +229,7 @@ class BIDSVariable(metaclass=ABCMeta):
             data['condition'] = self.name
 
         if entities:
+            # BUG #1275 - injects subjec=0 when 'run' column in only some dfs
             ent_data = self.index.reset_index(drop=True)
             data = pd.concat([data, ent_data], axis=1, sort=True)
 
@@ -559,7 +560,7 @@ class DenseRunVariable(BIDSVariable):
                 for k, v in all_ents[i].items():
                     col_ix = np.where(all_keys == k)[0][0]
                     df.iloc[prev_ix : prev_ix + reps, col_ix] = v
-                prev_ix = reps
+                prev_ix += reps
 
             return df
 


### PR DESCRIPTION
This hopefully fixes https://github.com/bids-standard/pybids/issues/604 and #1275: In `synthetic`, T1w and rest rows of scans.tsv were not in `to_df()` output -- columns with run as `np.NaN` are excluded. 

The pull requests has ~two~ three changes
  1. replaces any `None` values over all columns in the long-dataframe  with `n/a` . `pivot_table(...,dropna=False)` would be a a nicer solution but it creates too many rows (all permutations of missing?).
  2. removes hard coded pivoting `valid_vars`. Instead the pivot from long back to wide uses all columns except the to-wide `condition` and `amplitude`.
  3. add `+=` DenseRunVariable for constructing data frame row ranges

New tests are run against the `synthetic` dataset for `level="session"` and `level="run"`. There might be other yet-tested usage of the original `valid_vars` / `to_df()` calls. 
```
{'run', 'session', 'subject', 'dataset', 'onset', 'duration'} # previously (last 3 dropped)
['run', 'session', 'subject', 'datatype', 'suffix', 'task']   # this PR for synthetic scans.tsv
```


-----

The PR tries to resolve issues with the current `pivot_wide` logic. That part (wide input `to_df()`)  and the proposed solution look like

```
import pandas as pd
from numpy import nan
dput = {'amplitude': ['1880-01-10T05:17:54', '1880-01-10T05:22:54', '1880-01-10T05:37:54', '1880-01-10T05:52:54', 8.0, 'n/a', 'n/a', 'n/a', 0.0029, 0.03, 0.03, 0.03, 'n/a', 'N-Back', 'N-Back', 'Rest', 2.5, 2.5, 2.5, 2.5], 'condition': ['acq_time', 'acq_time', 'acq_time', 'acq_time', 'FlipAngle', 'FlipAngle', 'FlipAngle', 'FlipAngle', 'EchoTime', 'EchoTime', 'EchoTime', 'EchoTime', 'TaskName', 'TaskName', 'TaskName', 'TaskName', 'RepetitionTime', 'RepetitionTime', 'RepetitionTime', 'RepetitionTime'], 'datatype': ['anat', 'func', 'func', 'func', 'anat', 'func', 'func', 'func', 'anat', 'func', 'func', 'func', 'anat', 'func', 'func', 'func', 'anat', 'func', 'func', 'func'], 'run': [nan, 1.0, 2.0, nan, nan, 1.0, 2.0, nan, nan, 1.0, 2.0, nan, nan, 1.0, 2.0, nan, nan, 1.0, 2.0, nan], 'session': ['01', '01', '01', '01', '01', '01', '01', '01', '01', '01', '01', '01', '01', '01', '01', '01', '01', '01', '01', '01'], 'subject': ['01', '01', '01', '01', '01', '01', '01', '01', '01', '01', '01', '01', '01', '01', '01', '01', '01', '01', '01', '01'], 'suffix': ['T1w', 'bold', 'bold', 'bold', 'T1w', 'bold', 'bold', 'bold', 'T1w', 'bold', 'bold', 'bold', 'T1w', 'bold', 'bold', 'bold', 'T1w', 'bold', 'bold', 'bold'], 'task': [nan, 'nback', 'nback', 'rest', nan, 'nback', 'nback', 'rest', nan, 'nback', 'nback', 'rest', nan, 'nback', 'nback', 'rest', nan, 'nback', 'nback', 'rest']}
df = pd.DataFrame(dput)
for col in df.columns:
    df[col] = df[col].fillna('n/a')
idx_cols = df.columns.difference(['condition', 'amplitude']).to_list()
wide_df = df.pivot_table(
    index=idx_cols, columns='condition', values='amplitude', aggfunc='first'
)
```
