### PR TITLE
[FIX] Restrict entity parsing to the dataset root

### DIFF
--- a/src/bids/layout/index.py
+++ b/src/bids/layout/index.py
@@ -270,14 +270,10 @@ class BIDSLayoutIndexer:
         """Create DB record for file and its tags."""
         bf = make_bidsfile(abs_fn)
 
-        # Extract entity values
-        match_vals = {}
-        for e in entities.values():
-            m = e.match_file(bf)
-            if m is None and e.mandatory:
-                break
-            if m is not None:
-                match_vals[e.name] = (e, m)
+        # Entity patterns must not match directories above the dataset root.
+        root = Path(self._layout._root.path)
+        relative_fn = Path('/') / Path(abs_fn.path).relative_to(root)
+        match_vals = _extract_entities(make_bidsfile(relative_fn), entities)
 
         # Create Entity <=> BIDSFile mappings
         tag_dicts = [

--- a/src/bids/layout/tests/test_layout.py
+++ b/src/bids/layout/tests/test_layout.py
@@ -29,6 +29,27 @@ def test_layout_init(layout_7t_trt):
     assert isinstance(layout_7t_trt.files, dict)
 
 
+def test_entities_are_parsed_below_dataset_root(tmp_path):
+    root = tmp_path / 'sub-wrong' / 'motion' / 'BIDS'
+    func = root / 'sub-001' / 'func'
+    func.mkdir(parents=True)
+    (root / 'dataset_description.json').write_text(
+        json.dumps({'Name': 'root boundary', 'BIDSVersion': '1.10.1'})
+    )
+    bold = func / 'sub-001_task-test_bold.nii.gz'
+    bold.touch()
+
+    layout = BIDSLayout(root, validate=False)
+
+    assert layout.get_file(bold).entities == {
+        'datatype': 'func',
+        'extension': '.nii.gz',
+        'subject': '001',
+        'suffix': 'bold',
+        'task': 'test',
+    }
+
+
 @pytest.mark.parametrize(
     'index_metadata,filters,result',
     [


### PR DESCRIPTION
Closes #1270.

Entity patterns were matched against absolute file paths during indexing. If a directory above the dataset root had an entity-like name, it could be selected before the entity inside the dataset. For example, `/projects/motion/BIDS/sub-001/func/...` was indexed with `datatype=motion`.

This change parses entities from a root-relative path while keeping stored file paths absolute. The regression test also checks that an entity-like subject directory above the root is ignored.

Tests:
- `pytest -q --ignore=src/bids/layout/tests/test_remote_bids.py` (360 passed, 96 skipped)
- `pytest -q -rx src/bids/layout/tests/test_remote_bids.py` (1 expected xfail)